### PR TITLE
fix: fragment encoding

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -4,48 +4,55 @@ const fasturi = require('./')
 const urijs = require('uri-js')
 
 const base = 'uri://a/b/c/d;p?q'
+
+const domain = 'https://example.com/foo#bar$fiz'
+const ipv4 = '//10.10.10.10'
+const ipv6 = '//[2001:db8::7]'
+const urn = 'urn:foo:a123,456'
+const urnuuid = 'urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6'
+
 // Initialization as there is a lot to parse at first
 // eg: regexes
-fasturi.parse('https://example.com')
-urijs.parse('https://example.com')
+fasturi.parse(domain)
+urijs.parse(domain)
 
 suite.add('fast-uri: parse domain', function () {
-  fasturi.parse('https://example.com')
+  fasturi.parse(domain)
 })
 suite.add('urijs: parse domain', function () {
-  urijs.parse('https://example.com')
+  urijs.parse(domain)
 })
 suite.add('WHATWG URL: parse domain', function () {
   // eslint-disable-next-line
-  new URL('https://example.com')
+  new URL(domain)
 })
 suite.add('fast-uri: parse IPv4', function () {
-  fasturi.parse('//10.10.10.10')
+  fasturi.parse(ipv4)
 })
 suite.add('urijs: parse IPv4', function () {
-  urijs.parse('//10.10.10.10')
+  urijs.parse(ipv4)
 })
 suite.add('fast-uri: parse IPv6', function () {
-  fasturi.parse('//[2001:db8::7]')
+  fasturi.parse(ipv6)
 })
 suite.add('urijs: parse IPv6', function () {
-  urijs.parse('//[2001:db8::7]')
+  urijs.parse(ipv6)
 })
 suite.add('fast-uri: parse URN', function () {
-  fasturi.parse('urn:foo:a123,456')
+  fasturi.parse(urn)
 })
 suite.add('urijs: parse URN', function () {
-  urijs.parse('urn:foo:a123,456')
+  urijs.parse(urn)
 })
 suite.add('WHATWG URL: parse URN', function () {
   // eslint-disable-next-line
-  new URL('urn:foo:a123,456')
+  new URL(urn)
 })
 suite.add('fast-uri: parse URN uuid', function () {
-  fasturi.parse('urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6')
+  fasturi.parse(urnuuid)
 })
 suite.add('urijs: parse URN uuid', function () {
-  urijs.parse('urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6')
+  urijs.parse(urnuuid)
 })
 suite.add('fast-uri: serialize uri', function () {
   fasturi.serialize({

--- a/index.js
+++ b/index.js
@@ -274,10 +274,10 @@ function parse (uri, opts) {
         parsed.host = unescape(parsed.host)
       }
       if (parsed.path !== undefined && parsed.path.length) {
-        parsed.path = escape(parsed.path)
+        parsed.path = encodeURI(parsed.path)
       }
       if (parsed.fragment !== undefined && parsed.fragment.length) {
-        parsed.fragment = escape(parsed.fragment)
+        parsed.fragment = encodeURI(decodeURI(parsed.fragment))
       }
     }
 

--- a/test/compatibility.test.js
+++ b/test/compatibility.test.js
@@ -32,6 +32,8 @@ test('compatibility Parse', (t) => {
     '//[2606:2800:220:1:248:1893:25c8:1946:43209]',
     'http://foo.bar',
     'http://',
+    '#/$defs/stringMap',
+    '#/$defs/string%20Map',
     '//?json=%7B%22foo%22%3A%22bar%22%7D'
     //  'mailto:chris@example.com'-203845,
     //  'mailto:infobot@example.com?subject=current-issue',

--- a/test/compatibility.test.js
+++ b/test/compatibility.test.js
@@ -34,6 +34,7 @@ test('compatibility Parse', (t) => {
     'http://',
     '#/$defs/stringMap',
     '#/$defs/string%20Map',
+    '#/$defs/string Map',
     '//?json=%7B%22foo%22%3A%22bar%22%7D'
     //  'mailto:chris@example.com'-203845,
     //  'mailto:infobot@example.com?subject=current-issue',


### PR DESCRIPTION
[Draft]
currently having issue with fragment encoding like:
-   #/$defs/stringMap
-   #/$defs/string%20Map

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
