### PR TITLE
fix: skip colon encoding when schema exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,10 @@ function serialize (cmpts, opts) {
   if (components.path !== undefined) {
     if (!options.skipEscape) {
       components.path = escape(components.path)
+
+      if (components.scheme !== undefined) {
+        components.path = components.path.split('%3A').join(':')
+      }
     } else {
       components.path = unescape(components.path)
     }

--- a/test/compatibility.test.js
+++ b/test/compatibility.test.js
@@ -111,6 +111,10 @@ test('compatibility serialize', (t) => {
       host: 'example.com',
       resourceName: '/foo?bar',
       secure: true
+    },
+    {
+      scheme: 'scheme',
+      path: 'with:colon'
     }
   ]
   toSerialize.forEach((x) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Fixed #38. I didn't go deep into this problem. url-js encodes the path differently depending on whether the schema exists or not.

https://github.com/garycourt/uri-js/blob/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae/src/uri.ts#L152