### PR TITLE
perf: avoid domainToAscii on pure lowercase ascii cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,6 +178,8 @@ function serialize (cmpts, opts) {
   return uriTokens.join('')
 }
 
+const NON_ASCII_HOST = /[^!"$&'()*+,.;=_`a-z{}~-]/
+
 const URI_PARSE = /^(?:([^:/?#]+):)?(?:\/\/((?:([^/?#@]*)@)?(\[[^/?#\]]+\]|[^/?#:]*)(?::(\d*))?))?([^?#]*)(?:\?([^#]*))?(?:#((?:.|\n|\r)*))?/i
 
 function parse (uri, opts) {
@@ -239,7 +241,7 @@ function parse (uri, opts) {
     // check if scheme can't handle IRIs
     if (!options.unicodeSupport && (!schemeHandler || !schemeHandler.unicodeSupport)) {
       // if host component is a domain name
-      if (parsed.host && (options.domainHost || (schemeHandler && schemeHandler.domainHost))) {
+      if (parsed.host && (options.domainHost || (schemeHandler && schemeHandler.domainHost)) && NON_ASCII_HOST.test(parsed.host)) {
         // convert Unicode IDN -> ASCII IDN
         try {
           parsed.host = URL.domainToASCII(parsed.host.toLowerCase())


### PR DESCRIPTION
before:
```sh
fast-uri: parse domain x 691,379 ops/sec ±0.47% (94 runs sampled)
urijs: parse domain x 316,209 ops/sec ±0.41% (95 runs sampled)
WHATWG URL: parse domain x 2,326,414 ops/sec ±0.33% (90 runs sampled)
fast-uri: parse IPv4 x 1,658,275 ops/sec ±0.25% (96 runs sampled)
urijs: parse IPv4 x 277,154 ops/sec ±0.95% (93 runs sampled)
fast-uri: parse IPv6 x 707,699 ops/sec ±0.29% (95 runs sampled)
urijs: parse IPv6 x 210,365 ops/sec ±1.34% (91 runs sampled)
fast-uri: parse URN x 1,682,084 ops/sec ±0.25% (96 runs sampled)
urijs: parse URN x 813,089 ops/sec ±0.24% (94 runs sampled)
WHATWG URL: parse URN x 3,321,670 ops/sec ±0.30% (91 runs sampled)
fast-uri: parse URN uuid x 1,175,383 ops/sec ±0.26% (94 runs sampled)
urijs: parse URN uuid x 604,137 ops/sec ±0.24% (92 runs sampled)
fast-uri: serialize uri x 945,225 ops/sec ±0.80% (95 runs sampled)
urijs: serialize uri x 284,622 ops/sec ±0.30% (92 runs sampled)
fast-uri: serialize IPv6 x 337,427 ops/sec ±0.66% (94 runs sampled)
urijs: serialize IPv6 x 183,875 ops/sec ±0.61% (96 runs sampled)
fast-uri: serialize ws x 902,500 ops/sec ±0.23% (96 runs sampled)
urijs: serialize ws x 253,735 ops/sec ±0.21% (94 runs sampled)
fast-uri: resolve x 249,328 ops/sec ±0.66% (95 runs sampled)
urijs: resolve x 164,304 ops/sec ±0.20% (97 runs sampled)
```

after:
```sh
fast-uri: parse domain x 1,180,480 ops/sec ±0.34% (90 runs sampled)
urijs: parse domain x 322,980 ops/sec ±0.17% (97 runs sampled)
WHATWG URL: parse domain x 2,340,656 ops/sec ±0.34% (94 runs sampled)
fast-uri: parse IPv4 x 1,594,761 ops/sec ±0.67% (93 runs sampled)
urijs: parse IPv4 x 273,783 ops/sec ±0.96% (95 runs sampled)
fast-uri: parse IPv6 x 691,538 ops/sec ±0.25% (88 runs sampled)
urijs: parse IPv6 x 214,914 ops/sec ±1.48% (93 runs sampled)
fast-uri: parse URN x 1,815,279 ops/sec ±0.25% (96 runs sampled)
urijs: parse URN x 863,531 ops/sec ±0.20% (95 runs sampled)
WHATWG URL: parse URN x 3,293,837 ops/sec ±0.30% (93 runs sampled)
fast-uri: parse URN uuid x 1,216,795 ops/sec ±0.21% (95 runs sampled)
urijs: parse URN uuid x 628,702 ops/sec ±0.18% (95 runs sampled)
fast-uri: serialize uri x 952,087 ops/sec ±0.61% (94 runs sampled)
urijs: serialize uri x 283,889 ops/sec ±0.35% (94 runs sampled)
fast-uri: serialize IPv6 x 338,960 ops/sec ±0.80% (96 runs sampled)
urijs: serialize IPv6 x 180,274 ops/sec ±0.58% (96 runs sampled)
fast-uri: serialize ws x 938,850 ops/sec ±0.29% (94 runs sampled)
urijs: serialize ws x 255,779 ops/sec ±0.21% (96 runs sampled)
fast-uri: resolve x 241,644 ops/sec ±1.24% (93 runs sampled)
urijs: resolve x 159,649 ops/sec ±1.25% (89 runs sampled)
```

Only thing i want to note:
nodes own: URL.domainToAscii('1') returns '0.0.0.1', the same for URL.domainToAscii('11') returns '0.0.0.11',
So basically transforms the decimal notation to the dot notation. Is this neglectable?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
