### PR TITLE
perf: make ipv4 regex faster

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ const { HEX } = require('./scopedChars')
 
 function normalizeIPv4 (host) {
   if (findToken(host, '.') < 3) { return { host, isIPV4: false } }
-  const matches = host.match(/^(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/) || []
+  const matches = host.match(/^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/) || []
   const [address] = matches
   if (address) {
     return { host: stripLeadingZeros(address, '.'), isIPV4: true }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ const { HEX } = require('./scopedChars')
 
 function normalizeIPv4 (host) {
   if (findToken(host, '.') < 3) { return { host, isIPV4: false } }
-  const matches = host.match(/^((?:25[0-5]|(?:2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/) || []
+  const matches = host.match(/^(?:25[0-5]|(?:2[0-4]|1\d|[1-9]|)\d)(?:\.(?:25[0-5]|(?:2[0-4]|1\d|[1-9]|)\d)){3}$/) || []
   const [address] = matches
   if (address) {
     return { host: stripLeadingZeros(address, '.'), isIPV4: true }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ const { HEX } = require('./scopedChars')
 
 function normalizeIPv4 (host) {
   if (findToken(host, '.') < 3) { return { host, isIPV4: false } }
-  const matches = host.match(/^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/) || []
+  const matches = host.match(/^((?:25[0-5]|(?:2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/) || []
   const [address] = matches
   if (address) {
     return { host: stripLeadingZeros(address, '.'), isIPV4: true }

--- a/test/compatibility.test.js
+++ b/test/compatibility.test.js
@@ -10,7 +10,7 @@ test('compatibility Parse', (t) => {
     '//www.g.com/error\n/bleh/bleh',
     'https://fastify.org',
     '//10.10.10.10',
-    '//10.10.000.10',
+    //'//10.10.000.10', <-- not a valid URI per URI spec: https://datatracker.ietf.org/doc/html/rfc5954#section-4.1
     '//[2001:db8::7%en0]',
     '//[2001:dbZ::1]:80',
     '//[2001:db8::1]:80',

--- a/test/compatibility.test.js
+++ b/test/compatibility.test.js
@@ -10,7 +10,7 @@ test('compatibility Parse', (t) => {
     '//www.g.com/error\n/bleh/bleh',
     'https://fastify.org',
     '//10.10.10.10',
-    //'//10.10.000.10', <-- not a valid URI per URI spec: https://datatracker.ietf.org/doc/html/rfc5954#section-4.1
+    // '//10.10.000.10', <-- not a valid URI per URI spec: https://datatracker.ietf.org/doc/html/rfc5954#section-4.1
     '//[2001:db8::7%en0]',
     '//[2001:dbZ::1]:80',
     '//[2001:db8::1]:80',


### PR DESCRIPTION
All credits for this regex to https://stackoverflow.com/a/36760050. 

The regex is both more correct and faster (https://esbench.com/bench/6532596e7ff73700a4debb6a). Examples:
previous regex recognized "01.01.01.01" or "1.1.000.1" as correct ipv4 regex, but those aren't valid as per https://datatracker.ietf.org/doc/html/rfc5954#section-4.1.

I made this PR as draft, because tests are failing due to expected normalization of the ip (https://github.com/fastify/fast-uri/blob/77b659c7853730bb07e5b888b5136c4c5a1aca86/test/parse.test.js#L178C27-L178C41), but should an IP be normalized that is not valid? 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
