### PR TITLE
fix: skip nonSimpleDomain when it is an IP

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,6 +205,7 @@ function parse (uri, opts) {
     fragment: undefined
   }
   const gotEncoding = uri.indexOf('%') !== -1
+  let isIP = false
   if (options.reference === 'suffix') uri = (options.scheme ? options.scheme + ':' : '') + '//' + uri
 
   const matches = uri.match(URI_PARSE)
@@ -226,9 +227,12 @@ function parse (uri, opts) {
     if (parsed.host) {
       const ipv4result = normalizeIPv4(parsed.host)
       if (ipv4result.isIPV4 === false) {
-        parsed.host = normalizeIPv6(ipv4result.host, { isIPV4: false }).host.toLowerCase()
+        const ipv6result = normalizeIPv6(ipv4result.host, { isIPV4: false })
+        parsed.host = ipv6result.host.toLowerCase()
+        isIP = ipv6result.isIPV6
       } else {
         parsed.host = ipv4result.host
+        isIP = true
       }
     }
     if (parsed.scheme === undefined && parsed.userinfo === undefined && parsed.host === undefined && parsed.port === undefined && !parsed.path && parsed.query === undefined) {
@@ -252,7 +256,7 @@ function parse (uri, opts) {
     // check if scheme can't handle IRIs
     if (!options.unicodeSupport && (!schemeHandler || !schemeHandler.unicodeSupport)) {
       // if host component is a domain name
-      if (parsed.host && (options.domainHost || (schemeHandler && schemeHandler.domainHost)) && nonSimpleDomain(parsed.host)) {
+      if (parsed.host && (options.domainHost || (schemeHandler && schemeHandler.domainHost)) && isIP === false && nonSimpleDomain(parsed.host)) {
         // convert Unicode IDN -> ASCII IDN
         try {
           parsed.host = URL.domainToASCII(parsed.host.toLowerCase())


### PR DESCRIPTION
while checking how we can improve compatibilty with uri-js it seems, that we could save some yoctoseconds if we skip the nonSimpleDomain if we have an IP