### PR TITLE
fix `urijs` fragment handling incompatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function serialize (cmpts, opts) {
         components.path = components.path.split('%3A').join(':')
       }
     } else {
-      components.path = unescape(components.path)
+      components.path = decodeURIComponent(components.path)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function serialize (cmpts, opts) {
         components.path = components.path.split('%3A').join(':')
       }
     } else {
-      components.path = decodeURIComponent(components.path)
+      components.path = unescape(components.path)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -280,7 +280,7 @@ function parse (uri, opts) {
         parsed.path = escape(unescape(parsed.path))
       }
       if (parsed.fragment !== undefined && parsed.fragment.length) {
-        parsed.fragment = encodeURI(decodeURI(parsed.fragment))
+        parsed.fragment = encodeURI(unescape(parsed.fragment))
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -280,7 +280,7 @@ function parse (uri, opts) {
         parsed.path = escape(unescape(parsed.path))
       }
       if (parsed.fragment !== undefined && parsed.fragment.length) {
-        parsed.fragment = encodeURI(unescape(parsed.fragment))
+        parsed.fragment = encodeURI(decodeURIComponent(parsed.fragment))
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:typescript": "tsd"
   },
   "devDependencies": {
+    "@fastify/pre-commit": "^2.1.0",
     "ajv": "^8.16.0",
     "benchmark": "^2.1.4",
     "coveralls": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:ci": "npm run test:lint && npm run test:unit -- --cov --coverage-report=lcovonly && npm run test:typescript"
   },
   "devDependencies": {
+    "ajv": "^8.16.0",
     "benchmark": "^2.1.4",
     "coveralls": "^3.1.1",
     "snazzy": "^9.0.0",

--- a/test/ajv.test.js
+++ b/test/ajv.test.js
@@ -1,0 +1,39 @@
+const AJV = require('ajv')
+const fastUri = require('../')
+const ajv = new AJV({
+  uriResolver: fastUri // comment this line to see it works with uri-js
+})
+const { test } = require('tap')
+
+test('ajv', t => {
+  t.plan(1)
+  const schema = {
+    $ref: '#/definitions/Record%3Cstring%2CPerson%3E',
+    definitions: {
+      Person: {
+        type: 'object',
+        properties: {
+          firstName: {
+            type: 'string'
+          }
+        }
+      },
+      'Record<string,Person>': {
+        type: 'object',
+        additionalProperties: {
+          $ref: '#/definitions/Person'
+        }
+      }
+    }
+  }
+
+  const data = {
+    joe: {
+      firstName: 'Joe'
+    }
+
+  }
+
+  const validate = ajv.compile(schema)
+  t.ok(validate(data))
+})


### PR DESCRIPTION
This fixes the fragment issue that breaks the Ajv integration

The reason for this one is just not fun... caused mainly by uri-js's different encoding and decoding mechanism when the fragment is not a valid URI part

We can trace it back to here: https://github.com/fastify/fast-uri/pull/23/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R280