### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/fastify/fast-uri/issues"
   },
   "homepage": "https://github.com/fastify/fast-uri",
+  "sideEffects": false,
   "scripts": {
     "bench": "node benchmark.js",
     "lint": "standard | snazzy",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/fastify/fast-uri/issues"
   },
   "homepage": "https://github.com/fastify/fast-uri",
+  "module": "./index.js",
   "sideEffects": false,
   "scripts": {
     "bench": "node benchmark.js",


### PR DESCRIPTION
Add `sideEffects: false` and `module` path, for better code split

This set help package works at commonjs and esm emulation

In code we have some named imports 
```
{
  SCHEMES,
  normalize,
  resolve,
  resolveComponents,
  equal,
  serialize,
  parse
}
```
but it is not tree shaked by bundler, and it use all functions for build.

profit: it will be less unused code at prod bundle (now - using named imports make no effect)
