### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ajv": "^8.16.0",
     "benchmark": "^2.1.4",
     "coveralls": "^3.1.1",
+    "eslint": "^9.17.0",
     "neostandard": "^0.12.0",
     "tape": "^5.8.1",
     "tsd": "^0.31.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.