### PR TITLE
refactor: remove unused params

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ function serialize (cmpts, opts) {
     uriTokens.push(components.scheme, ':')
   }
 
-  const authority = recomposeAuthority(components, options)
+  const authority = recomposeAuthority(components)
   if (authority !== undefined) {
     if (options.reference !== 'suffix') {
       uriTokens.push('//')
@@ -223,7 +223,7 @@ function parse (uri, opts) {
     if (parsed.host) {
       const ipv4result = normalizeIPv4(parsed.host)
       if (ipv4result.isIPV4 === false) {
-        const ipv6result = normalizeIPv6(ipv4result.host, { isIPV4: false })
+        const ipv6result = normalizeIPv6(ipv4result.host)
         parsed.host = ipv6result.host.toLowerCase()
         isIP = ipv6result.isIPV6
       } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,7 +96,7 @@ function getIPV6 (input) {
   return output
 }
 
-function normalizeIPv6 (host, opts = {}) {
+function normalizeIPv6 (host) {
   if (findToken(host, ':') < 2) { return { host, isIPV6: false } }
   const ipv6 = getIPV6(host)
 
@@ -199,7 +199,7 @@ function normalizeComponentEncoding (components, esc) {
   return components
 }
 
-function recomposeAuthority (components, options) {
+function recomposeAuthority (components) {
   const uriTokens = []
 
   if (components.userinfo !== undefined) {
@@ -214,7 +214,7 @@ function recomposeAuthority (components, options) {
     if (ipV4res.isIPV4) {
       host = ipV4res.host
     } else {
-      const ipV6res = normalizeIPv6(ipV4res.host, { isIPV4: false })
+      const ipV6res = normalizeIPv6(ipV4res.host)
       if (ipV6res.isIPV6 === true) {
         host = `[${ipV6res.escapedHost}]`
       } else {


### PR DESCRIPTION
`recomposeAuthority`'s options param and `normalizeIPv6`s opts param are not used inside the respective functions, so this PR removes them.
Probably a teeny tiny performance boost as unused objects don't need to be initialised now either.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
