### PR TITLE
perf(index): use optional chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function serialize (cmpts, opts) {
   const schemeHandler = SCHEMES[(options.scheme || components.scheme || '').toLowerCase()]
 
   // perform scheme specific serialization
-  if (schemeHandler && schemeHandler.serialize) schemeHandler.serialize(components, options)
+  if (schemeHandler?.serialize) schemeHandler.serialize(components, options)
 
   if (components.path !== undefined) {
     if (!options.skipEscape) {
@@ -252,7 +252,7 @@ function parse (uri, opts) {
     // check if scheme can't handle IRIs
     if (!options.unicodeSupport && (!schemeHandler || !schemeHandler.unicodeSupport)) {
       // if host component is a domain name
-      if (parsed.host && (options.domainHost || (schemeHandler && schemeHandler.domainHost)) && isIP === false && nonSimpleDomain(parsed.host)) {
+      if (parsed.host && (options.domainHost || schemeHandler?.domainHost) && isIP === false && nonSimpleDomain(parsed.host)) {
         // convert Unicode IDN -> ASCII IDN
         try {
           parsed.host = URL.domainToASCII(parsed.host.toLowerCase())
@@ -270,16 +270,16 @@ function parse (uri, opts) {
       if (gotEncoding && parsed.host !== undefined) {
         parsed.host = unescape(parsed.host)
       }
-      if (parsed.path !== undefined && parsed.path.length) {
+      if (parsed.path?.length) {
         parsed.path = escape(unescape(parsed.path))
       }
-      if (parsed.fragment !== undefined && parsed.fragment.length) {
+      if (parsed.fragment?.length) {
         parsed.fragment = encodeURI(decodeURIComponent(parsed.fragment))
       }
     }
 
     // perform scheme specific parsing
-    if (schemeHandler && schemeHandler.parse) {
+    if (schemeHandler?.parse) {
       schemeHandler.parse(parsed, options)
     }
   } else {


### PR DESCRIPTION
Teeny tiny bit faster for a single hop: https://github.com/RafaelGSS/nodejs-bench-operations/blob/main/RESULTS-v22.md#optional-chain--vs--operator

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
