### PR TITLE
ci: set permissions at workflow level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - 'docs/**'
       - '*.md'
 
+permissions:
+  contents: read
+
 jobs:
   test-regression-check-node10:
     name: Test compatibility with Node.js 10
@@ -48,9 +51,6 @@ jobs:
           NODE_OPTIONS: no-network-family-autoselection
 
   test:
-    permissions:
-      contents: write
-      pull-requests: write
     needs:
       - test-regression-check-node10
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v5


### PR DESCRIPTION
This is a batch PR. This change stops security tools like step-security from complaining.