### PR TITLE
fix(lib/utils): simpler algorithm for removeDotSegments

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -78,6 +78,28 @@ suite.add('urijs: serialize uri', function () {
     fragment: 'fragment'
   })
 })
+suite.add('fast-uri: serialize long uri with dots', function () {
+  fasturi.serialize({
+    scheme: 'uri',
+    userinfo: 'foo:bar',
+    host: 'example.com',
+    port: 1,
+    path: './a/./b/c/../.././d/../e/f/.././/',
+    query: 'query',
+    fragment: 'fragment'
+  })
+})
+suite.add('urijs: serialize long uri with dots', function () {
+  urijs.serialize({
+    scheme: 'uri',
+    userinfo: 'foo:bar',
+    host: 'example.com',
+    port: 1,
+    path: './a/./b/c/../.././d/../e/f/.././/',
+    query: 'query',
+    fragment: 'fragment'
+  })
+})
 suite.add('fast-uri: serialize IPv6', function () {
   fasturi.serialize({ host: '2606:2800:220:1:248:1893:25c8:1946' })
 })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -192,9 +192,11 @@ function removeDotSegments (path) {
       if (input[1] === '.') {
         if (input[2] === '/') {
           input = input.slice(3)
+          continue;
         }
       } else if (input[1] === '/') {
         input = input.slice(2)
+        continue;
       }
     } else if (input[0] === '/') {
       if (input[1] === '.') {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -161,7 +161,8 @@ function removeDotSegments (path) {
       // Rule 2B: Replace "/./" or "/." with "/"
       input = input.slice(2)
     } else if (input === '/.') {
-      input = '/'
+      output.push('/')
+      break
     } else if (input.startsWith('/../')) {
       // Rule 2C: Replace "/../" or "/.." with "/" and remove last output segment
       input = input.slice(3)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,35 +146,53 @@ function findToken (str, token) {
   return ind
 }
 
-const RDS1 = /^\.\.?\//u
-const RDS2 = /^\/\.(?:\/|$)/u
-const RDS3 = /^\/\.\.(?:\/|$)/u
-const RDS5 = /^\/?(?:.|\n)*?(?=\/|$)/u
-
-function removeDotSegments (input) {
+// RFC 5.2.4
+function removeDotSegments (path) {
+  let input = path
   const output = []
 
-  while (input.length) {
-    if (input.match(RDS1)) {
-      input = input.replace(RDS1, '')
-    } else if (input.match(RDS2)) {
-      input = input.replace(RDS2, '/')
-    } else if (input.match(RDS3)) {
-      input = input.replace(RDS3, '/')
-      output.pop()
+  while (input.length > 0) {
+    // Rule 2A: Remove leading "../" or "./"
+    if (input.startsWith('../')) {
+      input = input.slice(3)
+    } else if (input.startsWith('./')) {
+      input = input.slice(2)
+    } else if (input.startsWith('/./')) {
+      // Rule 2B: Replace "/./" or "/." with "/"
+      input = '/' + input.slice(3)
+    } else if (input === '/.') {
+      input = '/'
+    } else if (input.startsWith('/../')) {
+      // Rule 2C: Replace "/../" or "/.." with "/" and remove last output segment
+      input = '/' + input.slice(4)
+      if (output.length > 0) {
+        output.pop()
+      }
+    } else if (input === '/..') {
+      input = '/'
+      if (output.length > 0) {
+        output.pop()
+      }
     } else if (input === '.' || input === '..') {
+      // Rule 2D: Remove lone "." or ".."
       input = ''
     } else {
-      const im = input.match(RDS5)
-      if (im) {
-        const s = im[0]
-        input = input.slice(s.length)
-        output.push(s)
+      // Rule 2E: Move normal path segment to output
+      const nextSlash = input.indexOf('/', 1)
+      let segment
+
+      if (nextSlash === -1) {
+        segment = input
+        input = ''
       } else {
-        throw new Error('Unexpected dot segment condition')
+        segment = input.slice(0, nextSlash)
+        input = input.slice(nextSlash)
       }
+
+      output.push(segment)
     }
   }
+
   return output.join('')
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -170,13 +170,14 @@ function removeDotSegments (path) {
         output.pop()
       }
     } else if (input === '/..') {
-      input = '/'
       if (output.length > 0) {
         output.pop()
       }
+      output.push('/')
+      break
     } else if (input === '.' || input === '..') {
       // Rule 2D: Remove lone "." or ".."
-      input = ''
+      break
     } else {
       // Rule 2E: Move normal path segment to output
       const nextSlash = input.indexOf('/', 1)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -192,11 +192,11 @@ function removeDotSegments (path) {
       if (input[1] === '.') {
         if (input[2] === '/') {
           input = input.slice(3)
-          continue;
+          continue
         }
       } else if (input[1] === '/') {
         input = input.slice(2)
-        continue;
+        continue
       }
     } else if (input[0] === '/') {
       if (input[1] === '.') {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -164,7 +164,7 @@ function removeDotSegments (path) {
       input = '/'
     } else if (input.startsWith('/../')) {
       // Rule 2C: Replace "/../" or "/.." with "/" and remove last output segment
-      input = '/' + input.slice(4)
+      input = input.slice(3)
       if (output.length > 0) {
         output.pop()
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,7 +146,7 @@ function findToken (str, token) {
   return ind
 }
 
-// RFC 5.2.4
+// RFC and Algorithm - https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
 function removeDotSegments (path) {
   let input = path
   const output = []

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,52 +146,80 @@ function findToken (str, token) {
   return ind
 }
 
-// RFC and Algorithm - https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
+// RFC - https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
 function removeDotSegments (path) {
   let input = path
   const output = []
+  let nextSlash = -1
+  let len = 0
 
-  while (input.length > 0) {
-    // Rule 2A: Remove leading "../" or "./"
-    if (input.startsWith('../')) {
-      input = input.slice(3)
-    } else if (input.startsWith('./')) {
-      input = input.slice(2)
-    } else if (input.startsWith('/./')) {
-      // Rule 2B: Replace "/./" or "/." with "/"
-      input = input.slice(2)
-    } else if (input === '/.') {
-      output.push('/')
-      break
-    } else if (input.startsWith('/../')) {
-      // Rule 2C: Replace "/../" or "/.." with "/" and remove last output segment
-      input = input.slice(3)
-      if (output.length > 0) {
-        output.pop()
+  // eslint-disable-next-line no-cond-assign
+  while (len = input.length) {
+    if (len === 1) {
+      if (input === '.') {
+        break
+      } else if (input === '/') {
+        output.push('/')
+        break
+      } else {
+        output.push(input)
+        break
       }
-    } else if (input === '/..') {
-      if (output.length > 0) {
-        output.pop()
+    } else if (len === 2) {
+      if (input[0] === '.') {
+        if (input[1] === '.') {
+          break
+        } else if (input[1] === '/') {
+          input = input.slice(2)
+          continue
+        }
+      } else if (input[0] === '/') {
+        if (input[1] === '.' || input[1] === '/') {
+          output.push('/')
+          break
+        }
       }
-      output.push('/')
-      break
-    } else if (input === '.' || input === '..') {
-      // Rule 2D: Remove lone "." or ".."
+    } else if (len === 3) {
+      if (input === '/..') {
+        if (output.length !== 0) {
+          output.pop()
+        }
+        output.push('/')
+        break
+      }
+    }
+    if (input[0] === '.') {
+      if (input[1] === '.') {
+        if (input[2] === '/') {
+          input = input.slice(3)
+        }
+      } else if (input[1] === '/') {
+        input = input.slice(2)
+      }
+    } else if (input[0] === '/') {
+      if (input[1] === '.') {
+        if (input[2] === '/') {
+          input = input.slice(2)
+          continue
+        } else if (input[2] === '.') {
+          if (input[3] === '/') {
+            input = input.slice(3)
+            if (output.length !== 0) {
+              output.pop()
+            }
+            continue
+          }
+        }
+      }
+    }
+
+    // Rule 2E: Move normal path segment to output
+    if ((nextSlash = input.indexOf('/', 1)) === -1) {
+      output.push(input)
       break
     } else {
-      // Rule 2E: Move normal path segment to output
-      const nextSlash = input.indexOf('/', 1)
-      let segment
-
-      if (nextSlash === -1) {
-        segment = input
-        input = ''
-      } else {
-        segment = input.slice(0, nextSlash)
-        input = input.slice(nextSlash)
-      }
-
-      output.push(segment)
+      output.push(input.slice(0, nextSlash))
+      input = input.slice(nextSlash)
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -159,7 +159,7 @@ function removeDotSegments (path) {
       input = input.slice(2)
     } else if (input.startsWith('/./')) {
       // Rule 2B: Replace "/./" or "/." with "/"
-      input = '/' + input.slice(3)
+      input = input.slice(2)
     } else if (input === '/.') {
       input = '/'
     } else if (input.startsWith('/../')) {

--- a/test/rfc-3986.test.js
+++ b/test/rfc-3986.test.js
@@ -1,0 +1,90 @@
+'use strict'
+
+const test = require('tape')
+const URI = require('../')
+
+test('RFC 3986', (t) => {
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+
+  // A.  If the input buffer begins with a prefix of "../" or "./",
+  //     then remove that prefix from the input buffer; otherwise,
+
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '../', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: './', secure: true }),
+    'http://example.com/', 'http://example.com/')
+
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '../../', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '././', secure: true }),
+    'http://example.com/', 'http://example.com/')
+
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: './../', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '.././', secure: true }),
+    'http://example.com/', 'http://example.com/')
+
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '../foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: './foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '../../foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '././foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: './../foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '.././foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+
+  // B.  if the input buffer begins with a prefix of "/./" or "/.",
+  //     where "." is a complete path segment, then replace that
+  //     prefix with "/" in the input buffer; otherwise,
+
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/./', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/.', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/./foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/.././foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+
+  // C.  if the input buffer begins with a prefix of "/../" or "/..",
+  //     where ".." is a complete path segment, then replace that
+  //     prefix with "/" in the input buffer and remove the last
+  //     segment and its preceding "/" (if any) from the output
+  //     buffer; otherwise,
+
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/../', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/..', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/../foo', secure: true }),
+    'http://example.com/foo', 'http://example.com/foo')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/foo/..', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/foo/bar/..', secure: true }),
+    'http://example.com/foo/', 'http://example.com/foo/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/foo/../bar/..', secure: true }),
+    'http://example.com/', 'http://example.com/')
+
+  // D.  if the input buffer consists only of "." or "..", then remove
+  //     that from the input buffer; otherwise,
+
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/.', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '/..', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '.', secure: true }),
+    'http://example.com/', 'http://example.com/')
+  t.strictEqual(URI.serialize({ scheme: 'http', host: 'example.com', path: '..', secure: true }),
+    'http://example.com/', 'http://example.com/')
+
+  t.end()
+})

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -2,7 +2,8 @@
 
 const test = require('tape')
 const {
-  stringArrayToHexStripped
+  stringArrayToHexStripped,
+  removeDotSegments
 } = require('../lib/utils')
 
 test('stringArrayToHexStripped', (t) => {
@@ -19,5 +20,19 @@ test('stringArrayToHexStripped', (t) => {
 
   testCases.forEach(([input, expected]) => {
     t.same(stringArrayToHexStripped(input[0], input[1]), expected)
+  })
+})
+
+// Just fixtures, because this function already tested by resolve
+test('removeDotSegments', (t) => {
+  const testCases = []
+  // https://github.com/fastify/fast-uri/issues/139
+  testCases.push(['WS:/WS://1305G130505:1&%0D:1&C(XXXXX*)))))))XXX130505:UUVUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa$aaaaaaaaaaaa13a',
+    'WS:/WS://1305G130505:1&%0D:1&C(XXXXX*)))))))XXX130505:UUVUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa$aaaaaaaaaaaa13a'])
+
+  t.plan(testCases.length)
+
+  testCases.forEach(([input, expected]) => {
+    t.same(removeDotSegments(input), expected)
   })
 })


### PR DESCRIPTION
Replace regex to linear algorithm. This fixes issue with fatal error/out of range. 
Closes #139 

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
