### PR TITLE
fix(lib/schemes/urn): check nid for undefined

### DIFF
--- a/lib/schemes.js
+++ b/lib/schemes.js
@@ -152,6 +152,9 @@ function urnParse (urnComponent, options) {
 
 /** @type {SchemeFn} */
 function urnSerialize (urnComponent, options) {
+  if (urnComponent.nid === undefined) {
+    throw new Error('URN without nid cannot be serialized')
+  }
   const scheme = options.scheme || urnComponent.scheme || 'urn'
   const nid = urnComponent.nid.toLowerCase()
   const urnScheme = `${scheme}:${options.nid || nid}`

--- a/test/equal.test.js
+++ b/test/equal.test.js
@@ -56,8 +56,7 @@ test('URN Equals', (t) => {
     // test from RFC 2141
     { pair: ['urn:foo:a123,456', 'urn:foo:a123,456'], result: true },
     { pair: ['urn:foo:a123,456', 'URN:foo:a123,456'], result: true },
-    { pair: ['urn:foo:a123,456', 'urn:FOO:a123,456'], result: true },
-    { pair: ['urn:', 'urn:FOO:a123,456'], result: false }
+    { pair: ['urn:foo:a123,456', 'urn:FOO:a123,456'], result: true }
   ]
 
   // Disabling for now as the whole equal logic might need

--- a/test/equal.test.js
+++ b/test/equal.test.js
@@ -56,7 +56,8 @@ test('URN Equals', (t) => {
     // test from RFC 2141
     { pair: ['urn:foo:a123,456', 'urn:foo:a123,456'], result: true },
     { pair: ['urn:foo:a123,456', 'URN:foo:a123,456'], result: true },
-    { pair: ['urn:foo:a123,456', 'urn:FOO:a123,456'], result: true }
+    { pair: ['urn:foo:a123,456', 'urn:FOO:a123,456'], result: true },
+    { pair: ['urn:', 'urn:FOO:a123,456'], result: false }
   ]
 
   // Disabling for now as the whole equal logic might need

--- a/test/equal.test.js
+++ b/test/equal.test.js
@@ -65,6 +65,11 @@ test('URN Equals', (t) => {
   // t.equal(URI.equal('urn:foo:a123%2C456', 'URN:FOO:a123%2c456'), true)
 
   runTest(t, suite)
+
+  t.throws(() => {
+    fn('urn:', 'urn:FOO:a123,456')
+  }, 'URN without nid cannot be serialized')
+
   t.end()
 })
 

--- a/test/serialize.test.js
+++ b/test/serialize.test.js
@@ -101,7 +101,7 @@ test('WSS serialize', (t) => {
 })
 
 test('URN serialize', (t) => {
-// example from RFC 2141
+  // example from RFC 2141
   const components = {
     scheme: 'urn',
     nid: 'foo',
@@ -122,6 +122,15 @@ test('URN serialize', (t) => {
     uuid: 'notauuid-7dec-11d0-a765-00a0c91e6bf6'
   }
   t.equal(fastURI.serialize(uuidcomponents), 'urn:uuid:notauuid-7dec-11d0-a765-00a0c91e6bf6')
+  t.equal(fastURI.serialize(uuidcomponents), 'urn:uuid:notauuid-7dec-11d0-a765-00a0c91e6bf6')
+
+  uuidcomponents = {
+    scheme: 'urn',
+    nid: undefined,
+    uuid: 'notauuid-7dec-11d0-a765-00a0c91e6bf6'
+  }
+  t.throws(() => { fastURI.serialize(uuidcomponents) }, 'URN without nid cannot be serialized')
+
   t.end()
 })
 test('URN NID Override', (t) => {

--- a/test/serialize.test.js
+++ b/test/serialize.test.js
@@ -122,7 +122,6 @@ test('URN serialize', (t) => {
     uuid: 'notauuid-7dec-11d0-a765-00a0c91e6bf6'
   }
   t.equal(fastURI.serialize(uuidcomponents), 'urn:uuid:notauuid-7dec-11d0-a765-00a0c91e6bf6')
-  t.equal(fastURI.serialize(uuidcomponents), 'urn:uuid:notauuid-7dec-11d0-a765-00a0c91e6bf6')
 
   uuidcomponents = {
     scheme: 'urn',


### PR DESCRIPTION
In library a lot parse->serialize->parse->serialize calls. But while using parse call as argument we don't check error field. It's not bad, but I found one place that can shoot. Check added testcase.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at Object.urnSerialize [as serialize] (/src/node_modules/fast-uri/lib/schemes.js:102:33)
    at serialize (/src/node_modules/fast-uri/index.js:123:63)
    at Object.equal (/src/node_modules/fast-uri/index.js:84:12)
```



#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
