### PR TITLE
Exclude test and benchmark files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+test
+benchmark
+eslint.config.js
+tsconfig.json


### PR DESCRIPTION
## Summary

Adds a `.npmignore` to exclude test, benchmark, and config files from the published npm package.

The `test/` (~116KB) and `benchmark/` directories are shipped to npm but serve no purpose for consumers. With ~53M weekly downloads, excluding them reduces aggregate bandwidth.

## Changes

Added `.npmignore` to exclude:
- `test/`
- `benchmark/`
- `eslint.config.js`
- `tsconfig.json`