### PR TITLE
fix: import url from node to support domainToASCII

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const url = require('node:url')
 const { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizeComponentEncoding, isIPv4, nonSimpleDomain } = require('./lib/utils')
 const { SCHEMES, getSchemeHandler } = require('./lib/schemes')
 
@@ -290,7 +291,7 @@ function parse (uri, opts) {
       if (parsed.host && (options.domainHost || (schemeHandler && schemeHandler.domainHost)) && isIP === false && nonSimpleDomain(parsed.host)) {
         // convert Unicode IDN -> ASCII IDN
         try {
-          parsed.host = URL.domainToASCII(parsed.host.toLowerCase())
+          parsed.host = url.domainToASCII(parsed.host.toLowerCase())
         } catch (e) {
           parsed.error = parsed.error || "Host's domain name can not be converted to ASCII: " + e
         }

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -42,6 +42,18 @@ test('URI parse', (t) => {
   t.equal(components.query, undefined, 'query')
   t.equal(components.fragment, undefined, 'fragment')
 
+  // non simple domain with schemeHandler
+  components = fastURI.parse('https://foo-bar-123.example.com')
+  t.equal(components.error, undefined, 'host errors')
+  t.equal(components.scheme, 'https', 'scheme')
+  // t.equal(components.authority, "", "authority");
+  t.equal(components.userinfo, undefined, 'userinfo')
+  t.equal(components.host, 'foo-bar-123.example.com', 'host non simple domain')
+  t.equal(components.port, undefined, 'port')
+  t.equal(components.path, '', 'path')
+  t.equal(components.query, undefined, 'query')
+  t.equal(components.fragment, undefined, 'fragment')
+
   // port
   components = fastURI.parse('//:')
   t.equal(components.error, undefined, 'port errors')


### PR DESCRIPTION
No test was covering the usage of URL.domainToASCII which is failing in the current state.

The added test returns this without the fix:

```
not ok 59 host errors
  ---
    operator: equal
    expected: |-
      undefined
    actual: |-
      'Host\'s domain name can not be converted to ASCII: TypeError: URL.domainToASCII is not a function'
    at: Test.<anonymous> (/Users/sebastiengaya/_Dev/SebouChu/fast-uri/test/parse.test.js:47:5)
    stack: |-
      Error: host errors
          at Test.assert [as _assert] (/Users/sebastiengaya/_Dev/SebouChu/fast-uri/node_modules/tape/lib/test.js:492:48)
          at Test.strictEqual (/Users/sebastiengaya/_Dev/SebouChu/fast-uri/node_modules/tape/lib/test.js:670:7)
          at Test.<anonymous> (/Users/sebastiengaya/_Dev/SebouChu/fast-uri/test/parse.test.js:47:5)
          at Test.run (/Users/sebastiengaya/_Dev/SebouChu/fast-uri/node_modules/tape/lib/test.js:126:28)
          at Immediate.next [as _onImmediate] (/Users/sebastiengaya/_Dev/SebouChu/fast-uri/node_modules/tape/lib/results.js:158:7)
          at process.processImmediate (node:internal/timers:504:21)
  ...
```

So we import the url module from Node to support the function.

Open to any suggestions if needed, thanks!

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
