### PR TITLE
Handle malformed fragment decoding as a parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -311,7 +311,11 @@ function parse (uri, opts) {
         parsed.path = escape(unescape(parsed.path))
       }
       if (parsed.fragment) {
-        parsed.fragment = encodeURI(decodeURIComponent(parsed.fragment))
+        try {
+          parsed.fragment = encodeURI(decodeURIComponent(parsed.fragment))
+        } catch {
+          parsed.error = parsed.error || 'URI malformed'
+        }
       }
     }
 

--- a/test/equal.test.js
+++ b/test/equal.test.js
@@ -106,3 +106,12 @@ test('WSS Equal', (t) => {
   runTest(t, suite)
   t.end()
 })
+
+test('URI Equals tolerates malformed fragments', (t) => {
+  t.equal(
+    fastURI.equal('http://example.com/#%E0%A4A', 'http://example.com/#%E0%A4A'),
+    true,
+    'malformed fragment does not throw during equality checks'
+  )
+  t.end()
+})

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -150,6 +150,11 @@ test('URI parse', (t) => {
   t.equal(components.query, undefined, 'query')
   t.equal(components.fragment, '%0D', 'fragment')
 
+  // malformed percent-encoded fragment must not throw
+  components = fastURI.parse('http://example.com/#%E0%A4A')
+  t.equal(components.error, 'URI malformed', 'malformed fragment errors')
+  t.equal(components.fragment, '%E0%A4A', 'malformed fragment is preserved')
+
   // all
   components = fastURI.parse('uri://user:pass@example.com:123/one/two.three?q1=a1&q2=a2#body')
   t.equal(components.error, undefined, 'all errors')

--- a/test/resolve.test.js
+++ b/test/resolve.test.js
@@ -76,3 +76,12 @@ test('URN Resolving', (t) => {
   t.equal(fastURI.resolve('urn:some:other:prop', 'urn:some:ip:prop'), 'urn:some:ip:prop', 'urn:some:ip:prop')
   t.end()
 })
+
+test('URI Resolving tolerates malformed fragments', (t) => {
+  t.equal(
+    fastURI.resolve('http://base.com/', 'http://example.com/#%E0%A4A'),
+    'http://example.com/#%E0%A4A',
+    'malformed fragment does not throw during resolve'
+  )
+  t.end()
+})


### PR DESCRIPTION
## Summary
- handle malformed fragment decoding as a parse error instead of throwing
- preserve the original fragment value when decoding fails
- add regression coverage for `parse()`, `resolve()`, and `equal()`

## Testing
- `npm test`
