### PR TITLE
chore: removed types deprecated

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,15 +28,6 @@ declare namespace fastUri {
     nid?: string;
   }
 
-  /**
-   * @deprecated Use Options instead
-   */
-  export type options = Options
-  /**
-   * @deprecated Use URIComponent instead
-   */
-  export type URIComponents = URIComponent
-
   export function normalize (uri: string, opts?: Options): string
   export function normalize (uri: URIComponent, opts?: Options): URIComponent
   export function normalize (uri: any, opts?: Options): any


### PR DESCRIPTION
Proposal:

- Drop `options` and `URIComponents` type aliases marked as `@deprecated` in favour of `Options` and `URIComponent`.


Note:

- Release a major version of the plugin after this pull request has been merged
- PR reference:
   - https://github.com/fastify/fastify-swagger-ui/pull/274