### PR TITLE
chore(ci): add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '23 4 * * 1'
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF's public dataset so the score becomes
+          # visible at api.securityscorecards.dev for downstream tooling.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Adds `.github/workflows/scorecard.yml` running the [`ossf/scorecard-action`](https://github.com/ossf/scorecard-action) on a weekly schedule, on pushes to `main`, and when branch protection rules change. Results are written to three places:
1. **OpenSSF's public dataset** (via `publish_results: true`) — so the score becomes queryable at `https://api.securityscorecards.dev/projects/github.com/fastify/fast-uri`.
2. **This repo's GitHub Security tab** — SARIF uploaded via `github/codeql-action/upload-sarif`.
3. **A run artifact** (`results.sarif`, 5-day retention) — convenient for inspecting findings without leaving the Actions page.

#### This to fix
GitHub's [dependency-review action](https://github.com/actions/dependency-review-action) shows the Scorecard column as **Unknown** for any consumer that depends on fast-uri.

#### Verification I ran locally
Ran the same checks the workflow will run, locally with the `scorecard` CLI:

```bash
scorecard --repo=github.com/fastify/fast-uri --show-details
```

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
