### PR TITLE
fix: normalize scheme to lowercase (RFC 3986 §6.2.2.1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ function parseWithStatus (uri, opts) {
 
   if (matches) {
     // store each component
-    parsed.scheme = matches[1]
+    parsed.scheme = matches[1] === undefined ? undefined : matches[1].toLowerCase()
     parsed.userinfo = matches[3]
     parsed.host = matches[4]
     parsed.port = parseInt(matches[5], 10)

--- a/test/scheme-normalization.test.js
+++ b/test/scheme-normalization.test.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+test('scheme is normalized to lowercase (RFC 3986 §6.2.2.1)', (t) => {
+  // parse lowercases the scheme, consistent with how it already lowercases the host
+  t.equal(fastURI.parse('HTTP://EXAMPLE.com/Path').scheme, 'http', 'parse lowercases an uppercase scheme')
+  t.equal(fastURI.parse('HtTpS://example.com').scheme, 'https', 'parse lowercases a mixed-case scheme')
+
+  // normalize emits a lowercase scheme (matches the already-lowercased host)
+  t.equal(fastURI.normalize('HTTP://EXAMPLE.com/p'), 'http://example.com/p', 'normalize lowercases the scheme')
+  t.equal(fastURI.normalize('HtTp://Example.COM/'), 'http://example.com/', 'normalize lowercases a mixed-case scheme')
+
+  t.end()
+})


### PR DESCRIPTION
### What

`parse()` does not lowercase the scheme, although it already lowercases the host:

```js
const fastUri = require('fast-uri')

fastUri.parse('HTTP://EXAMPLE.com/p').scheme   // 'HTTP'  (host is 'example.com')
fastUri.normalize('HTTP://EXAMPLE.com/p')      // 'HTTP://example.com/p'
```

### Why it's a bug

- **RFC 3986 §6.2.2.1** (Case Normalization): *"the scheme and host are case-insensitive and therefore should be normalized to lowercase."* The host is normalized; the scheme is not.
- `equal()` already lowercases the scheme when comparing (`fastUri.equal('HTTP://a', 'http://a') === true`), so the library already treats the scheme as case-insensitive — `normalize()`/`parse()` were just inconsistent with that.
- `uri-js` (which this library aims to be iso-compatible with) returns the lowercased scheme:

```js
require('uri-js').parse('HTTP://EXAMPLE.com/p').scheme   // 'http'
require('uri-js').normalize('HTTP://EXAMPLE.com/p')      // 'http://example.com/p'
```

### Change

Lowercase the scheme at parse time, next to where the host is already lowercased — one line, no new branches.

### Tests

Added `test/scheme-normalization.test.js` (red before the change, green after). Full `npm run test:unit` passes (878).