### PR TITLE
fix: normalize percent-encoding in query and fragment (RFC 3986 §6.2.2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require('./lib/utils')
+const { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, normalizeQueryFragmentEncoding, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require('./lib/utils')
 const { SCHEMES, getSchemeHandler } = require('./lib/schemes')
 
 /**
@@ -325,12 +325,11 @@ function parseWithStatus (uri, opts) {
       if (parsed.path) {
         parsed.path = normalizePathEncoding(parsed.path)
       }
+      if (parsed.query) {
+        parsed.query = normalizeQueryFragmentEncoding(parsed.query)
+      }
       if (parsed.fragment) {
-        try {
-          parsed.fragment = encodeURI(decodeURIComponent(parsed.fragment))
-        } catch {
-          parsed.error = parsed.error || 'URI malformed'
-        }
+        parsed.fragment = normalizeQueryFragmentEncoding(parsed.fragment)
       }
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,9 @@ const isUnreserved = RegExp.prototype.test.bind(/^[\da-z\-._~]$/iu)
 /** @type {(value: string) => boolean} */
 const isPathCharacter = RegExp.prototype.test.bind(/^[\da-z\-._~!$&'()*+,;=:@/]$/iu)
 
+/** @type {(value: string) => boolean} */
+const isQueryFragmentCharacter = RegExp.prototype.test.bind(/^[\da-z\-._~!$&'()*+,;=:@/?]$/iu)
+
 /**
  * @param {Array<string>} input
  * @returns {string}
@@ -436,6 +439,63 @@ function normalizePathEncoding (input) {
 }
 
 /**
+ * Normalizes the percent-encoding of a query or fragment component.
+ *
+ * Like `normalizePathEncoding`, but uses the query/fragment character set
+ * (which additionally allows `?`) and decodes `.` since it has no dot-segment
+ * meaning outside of a path.
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function normalizeQueryFragmentEncoding (input) {
+  let output = ''
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]
+    if (ch === '%' && i + 2 < input.length) {
+      const hex = input.slice(i + 1, i + 3)
+      if (isHexPair(hex)) {
+        const normalizedHex = hex.toUpperCase()
+        const decoded = String.fromCharCode(parseInt(normalizedHex, 16))
+
+        if (isUnreserved(decoded)) {
+          output += decoded
+        } else {
+          output += '%' + normalizedHex
+        }
+
+        i += 2
+        continue
+      }
+    }
+
+    if (isQueryFragmentCharacter(ch)) {
+      output += ch
+    } else {
+      const code = input.charCodeAt(i)
+      if (code < 0x80) {
+        output += isEscapeSafe(code) ? ch : BYTE_HEX[code]
+      } else if (code < 0xD800 || code > 0xDFFF) {
+        output += percentEncodeNonAscii(code)
+      } else if (code <= 0xDBFF && i + 1 < input.length) {
+        const low = input.charCodeAt(i + 1)
+        if (low >= 0xDC00 && low <= 0xDFFF) {
+          output += percentEncodeNonAscii(0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00))
+          i++
+        } else {
+          output += percentEncodeNonAscii(0xFFFD)
+        }
+      } else {
+        output += percentEncodeNonAscii(0xFFFD)
+      }
+    }
+  }
+
+  return output
+}
+
+/**
  * Escapes a component while preserving existing valid percent escapes.
  *
  * @param {string} input
@@ -515,6 +575,7 @@ module.exports = {
   reescapeHostDelimiters,
   normalizePercentEncoding,
   normalizePathEncoding,
+  normalizeQueryFragmentEncoding,
   escapePreservingEscapes,
   removeDotSegments,
   isIPv4,

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -150,10 +150,12 @@ test('URI parse', (t) => {
   t.equal(components.query, undefined, 'query')
   t.equal(components.fragment, '%0D', 'fragment')
 
-  // malformed percent-encoded fragment must not throw
+  // a fragment whose decoded bytes are not valid UTF-8 is still valid
+  // percent-encoding (RFC 3986 §2.1 is byte-level), so it is preserved as-is
+  // rather than being flagged as malformed
   components = fastURI.parse('http://example.com/#%E0%A4A')
-  t.equal(components.error, 'URI malformed', 'malformed fragment errors')
-  t.equal(components.fragment, '%E0%A4A', 'malformed fragment is preserved')
+  t.equal(components.error, undefined, 'valid percent-encoding is not flagged as malformed')
+  t.equal(components.fragment, '%E0%A4A', 'fragment is preserved')
 
   // all
   components = fastURI.parse('uri://user:pass@example.com:123/one/two.three?q1=a1&q2=a2#body')

--- a/test/query-fragment-normalization.test.js
+++ b/test/query-fragment-normalization.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+test('query percent-encoding is normalized (RFC 3986 §6.2.2)', (t) => {
+  // hex digits are uppercased, like the path component already does
+  t.equal(fastURI.normalize('x://h/p?a=%2a'), 'x://h/p?a=%2A', 'uppercases hex in query')
+  // unreserved characters are decoded
+  t.equal(fastURI.normalize('x://h/p?a=%7e%2e'), 'x://h/p?a=~.', 'decodes unreserved in query')
+  // reserved characters stay percent-encoded
+  t.equal(fastURI.normalize('x://h/p?a=%2F'), 'x://h/p?a=%2F', 'keeps reserved encoded in query')
+  // raw characters that are not allowed are percent-encoded
+  t.equal(fastURI.normalize('x://h/p?a b'), 'x://h/p?a%20b', 'encodes a raw space in query')
+  t.equal(fastURI.normalize('x://h/p?café'), 'x://h/p?caf%C3%A9', 'encodes raw non-ASCII in query')
+  // `?` is allowed unencoded in a query
+  t.equal(fastURI.normalize('x://h/p?a?b'), 'x://h/p?a?b', 'keeps `?` raw in query')
+
+  t.end()
+})
+
+test('fragment percent-encoding is normalized without decoding reserved characters', (t) => {
+  // reserved characters must NOT be decoded — `%2F` is not `/`
+  t.equal(fastURI.normalize('x://h/p#a%2Fb%2A'), 'x://h/p#a%2Fb%2A', 'keeps reserved encoded in fragment')
+  // hex is uppercased and unreserved is decoded
+  t.equal(fastURI.normalize('x://h/p#a%2a%7e'), 'x://h/p#a%2A~', 'uppercases hex and decodes unreserved in fragment')
+  // raw characters are still encoded
+  t.equal(fastURI.normalize('x://h/p#a b'), 'x://h/p#a%20b', 'encodes a raw space in fragment')
+  // `?` and `/` are allowed unencoded in a fragment
+  t.equal(fastURI.normalize('x://h/p#f?x/y'), 'x://h/p#f?x/y', 'keeps `?` and `/` raw in fragment')
+
+  t.end()
+})


### PR DESCRIPTION
### What

RFC 3986 §6.2.2 (case + percent-encoding normalization) is applied to the **path** but not to the **query** or **fragment**.

```js
const fastUri = require('fast-uri')

// query: not normalized at all
fastUri.normalize('x://h/p?a=%2a')   // 'x://h/p?a=%2a'   (hex not uppercased)
fastUri.normalize('x://h/p?a b')     // 'x://h/p?a b'     (raw space not encoded)

// fragment: reserved characters are decoded, changing the value
fastUri.normalize('x://h/p#a%2Fb')   // 'x://h/p#a/b'     (%2F became /)
```

### Why these are bugs

- **§6.2.2.1 (case):** *"all letters within a percent-encoding triplet ... should be normalized to use uppercase."* The path does this; the query did not.
- **§6.2.2.2 (percent-encoding):** decoding **must be limited to unreserved** characters. The fragment used `encodeURI(decodeURIComponent(fragment))`, which decodes reserved characters too, so `%2F` → `/` and `%2A` → `*` — a value change.
- `uri-js` (the iso-compat target) normalizes both: `?a=%2a` → `?a=%2A`, and keeps `#a%2Fb` as `#a%2Fb`.

### Change

Add `normalizeQueryFragmentEncoding` — the existing `normalizePathEncoding` with the query/fragment character set (which additionally permits `?` and decodes `.`, since there are no dot-segments outside a path) — and route the query and fragment through it. All three components are now normalized consistently:

| input | before | after |
| --- | --- | --- |
| `?a=%2a` | `?a=%2a` | `?a=%2A` |
| `?a b` | `?a b` | `?a%20b` |
| `#a%2Fb%2A` | `#a/b*` | `#a%2Fb%2A` |
| `#f?x/y` | `#f?x/y` | `#f?x/y` (unchanged) |

### One behavior change worth calling out

`encodeURI(decodeURIComponent(...))` threw on a fragment whose decoded bytes are not valid UTF-8 (e.g. `#%E0%A4A`), which the old code caught and flagged as `error: 'URI malformed'`. Such a fragment is still **valid percent-encoding** (RFC 3986 §2.1 is byte-level and does not require UTF-8), so it is now preserved without an error. The `'tolerates malformed fragments'` resolve/equal tests still pass; I updated the one parse assertion that checked for the error flag (the fragment value is unchanged).

### Tests

Added `test/query-fragment-normalization.test.js`. Full `npm run test:unit` passes (884), `eslint` clean.