### PR TITLE
fix: backport GHSA-4c8g-83qw-93j6 IDN host canonicalisation to v2.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ function parseWithStatus (uri, opts) {
       if (parsed.host && (options.domainHost || (schemeHandler && schemeHandler.domainHost)) && isIP === false && nonSimpleDomain(parsed.host)) {
         // convert Unicode IDN -> ASCII IDN
         try {
-          parsed.host = URL.domainToASCII(parsed.host.toLowerCase())
+          parsed.host = new URL('http://' + parsed.host).hostname
         } catch (e) {
           parsed.error = parsed.error || "Host's domain name can not be converted to ASCII: " + e
         }

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -132,3 +132,31 @@ test('normalize does not double-decode %2540 into a live @', (t) => {
   t.plan(1)
   t.not(parsed.host, 'trusted.com@evil.com', 'http://trusted.com%2540evil.com/')
 })
+
+test('parse canonicalises IDN / Unicode hosts to their ASCII form', (t) => {
+  const cases = [
+    {
+      input: 'http://127。0。0。1/',
+      expectedHost: '127.0.0.1',
+      description: 'full-width ideographic stops as octet separators'
+    },
+    {
+      input: 'http://ｅxample.com/',
+      expectedHost: 'example.com',
+      description: 'fullwidth e as first letter'
+    },
+    {
+      input: 'http://納豆.example.org/',
+      expectedHost: 'xn--99zt52a.example.org',
+      description: 'CJK label requiring punycode'
+    }
+  ]
+
+  t.plan(cases.length * 2)
+
+  cases.forEach(({ input, expectedHost, description }) => {
+    const parsed = fastURI.parse(input)
+    t.notOk(parsed.error, `parse should not set error: ${description}`)
+    t.equal(parsed.host, expectedHost, `host canonicalised to ASCII: ${description}`)
+  })
+})


### PR DESCRIPTION
## Summary

Backports [GHSA-4c8g-83qw-93j6](https://github.com/fastify/fast-uri/security/advisories/GHSA-4c8g-83qw-93j6) / CVE-2026-13676 to the `v2.x` release train.

`URL.domainToASCII` does not exist on the global WHATWG `URL` constructor. The resulting `TypeError` was swallowed into `parsed.error`, leaving Unicode/IDN hosts uncanonicalized. That desyncs host-policy checks from Node's URL/`fetch()` consumers (e.g. `http://127。0。0。1/` stays as host `127。0。0。1` while WHATWG resolves it to `127.0.0.1`).

### Fix

```js
// before
parsed.host = URL.domainToASCII(parsed.host.toLowerCase())

// after
parsed.host = new URL('http://' + parsed.host).hostname
```

Same change already shipped in `v3.1.3` and `v4.0.1`.

### Follow-up

After merge, publish `2.4.2` and update GHSA-4c8g-83qw-93j6 to list the new `2.x` patched version (advisory currently only lists `3.1.3` and `4.0.1`; vulnerable range includes `>= 2.3.1`).

## Test plan

- [x] Manual: `parse('http://127。0。0。1/').host === '127.0.0.1'`
- [x] Manual: fullwidth / CJK IDN cases canonicalise without `error`
- [x] `npm run test:unit` (includes new IDN regression test)
- [x] `npm run test:lint`
