### PR TITLE
docs: clarify security report scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,9 +11,14 @@ official Fastify project package. It supplements the Fastify project's
 [WHATWG URL Standard](https://url.spec.whatwg.org/).
 
 Differences between `fast-uri` and WHATWG URL implementations are expected.
-Reports based on comparing or mixing parsers that follow these different
+Reports based solely on comparing or mixing parsers that follow these different
 standards are out of scope. Applications must use the same parsing and
 normalization rules for both security decisions and subsequent URI use.
+
+Reports are assessed based on reproducibility, documented supported usage, and
+concrete security impact—not merely on whether they mention WHATWG URL
+behavior. Reports demonstrating a parsing or normalization flaw in a supported
+scheme remain eligible for evaluation.
 
 ## Threat model
 


### PR DESCRIPTION
## Summary

- clarify that parser-comparison-only reports are outside the security scope
- document that reports are assessed on reproducibility, supported usage, and concrete impact
- retain eligibility for supported-scheme parsing and normalization flaws even when WHATWG URL behavior is discussed

## Validation

- `git diff --check`
- `git show --check`
- tests not run (documentation-only change)
