### PR TITLE
test: cover encoded UTF-8 URI resolution

### DIFF
--- a/test/resolve.test.js
+++ b/test/resolve.test.js
@@ -85,3 +85,22 @@ test('URI Resolving tolerates malformed fragments', (t) => {
   )
   t.end()
 })
+
+test('URI resolving preserves percent-encoded UTF-8 path segments', (t) => {
+  t.equal(
+    fastURI.resolve('http://host', encodeURIComponent('ыы')),
+    'http://host/%D1%8B%D1%8B',
+    'keeps the issue reproduction as UTF-8 percent-encoding'
+  )
+
+  t.equal(
+    fastURI.resolve(
+      'json-schemer://schema',
+      '1c_list_Document_%D0%A1%D0%B1%D0%BE%D1%80%D0%BA%D0%B0%D0%97%D0%B0%D0%BF%D0%B0%D1%81%D0%BE%D0%B2'
+    ),
+    'json-schemer://schema/1c_list_Document_%D0%A1%D0%B1%D0%BE%D1%80%D0%BA%D0%B0%D0%97%D0%B0%D0%BF%D0%B0%D1%81%D0%BE%D0%B2',
+    'keeps the JSON Schema reference fixture percent-encoded'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
## Summary

- add regression coverage for [#157](https://github.com/fastify/fast-uri/issues/157), ensuring `resolve()` retains UTF-8 percent-encoded path segments instead of producing legacy `unescape()`-style Latin-1 output;
- cover the corresponding JSON Schema reference fixture from [sagold/json-schema-library#82](https://github.com/sagold/json-schema-library/issues/82), where `uri-js` had been used as a workaround;
- lock in the current implementation's correct behaviour without adding a dependency or changing public API.

## Context

The functional fix was already released in v3.1.1 via [876ce79](https://github.com/fastify/fast-uri/commit/876ce79b662c3e5015e4e7dffe6f37752ad34f35). This PR only adds regression coverage for that existing fix.

The commit credits the original report and fixture research:

`Co-authored-by: Dmitry Arkhipov <2089893+ekzobrain@users.noreply.github.com>`

Refs #157.

## Validation

- `npm test`
- `npm run lint`
- `npm run test:typescript`
- `npm run test:browser:chromium`
