### PR TITLE
fix: encode serialized URI components

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, normalizeQueryFragmentEncoding, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require('./lib/utils')
+const { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, normalizeQueryFragmentEncoding, encodeQuery, encodeFragment, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require('./lib/utils')
 const { SCHEMES, getSchemeHandler } = require('./lib/schemes')
 
 /**
@@ -226,11 +226,11 @@ function serialize (cmpts, opts) {
   }
 
   if (component.query !== undefined) {
-    uriTokens.push('?', component.query)
+    uriTokens.push('?', encodeQuery(component.query))
   }
 
   if (component.fragment !== undefined) {
-    uriTokens.push('#', component.fragment)
+    uriTokens.push('#', encodeFragment(component.fragment))
   }
   return uriTokens.join('')
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,10 @@ const isUnreserved = RegExp.prototype.test.bind(/^[\da-z\-._~]$/iu)
 const isPathCharacter = RegExp.prototype.test.bind(/^[\da-z\-._~!$&'()*+,;=:@/]$/iu)
 
 /** @type {(value: string) => boolean} */
-const isQueryFragmentCharacter = RegExp.prototype.test.bind(/^[\da-z\-._~!$&'()*+,;=:@/?]$/iu)
+const isQueryFragmentCharacter = RegExp.prototype.test.bind(/^[A-Za-z0-9\-._~!$&'()*+,;=:@/?]$/u)
+
+/** @type {(value: string) => boolean} */
+const isUserinfoCharacter = RegExp.prototype.test.bind(/^[A-Za-z0-9\-._~!$&'()*+,;=:]$/u)
 
 /**
  * @param {Array<string>} input
@@ -520,6 +523,85 @@ function normalizeQueryFragmentEncoding (input) {
 }
 
 /**
+ * Percent-encodes a URI component using its RFC 3986 literal character set.
+ * Existing valid escapes are preserved and normalized to uppercase hex.
+ *
+ * @param {string} input
+ * @param {(value: string) => boolean} isAllowed
+ * @returns {string}
+ */
+function encodeComponent (input, isAllowed) {
+  let output = ''
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]
+    if (ch === '%' && i + 2 < input.length) {
+      const hex = input.slice(i + 1, i + 3)
+      if (isHexPair(hex)) {
+        output += '%' + hex.toUpperCase()
+        i += 2
+        continue
+      }
+    }
+
+    if (isAllowed(ch)) {
+      output += ch
+    } else {
+      const code = input.charCodeAt(i)
+      if (code < 0x80) {
+        output += BYTE_HEX[code]
+      } else if (code < 0xD800 || code > 0xDFFF) {
+        output += percentEncodeNonAscii(code)
+      } else if (code <= 0xDBFF && i + 1 < input.length) {
+        const low = input.charCodeAt(i + 1)
+        if (low >= 0xDC00 && low <= 0xDFFF) {
+          output += percentEncodeNonAscii(0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00))
+          i++
+        } else {
+          output += percentEncodeNonAscii(0xFFFD)
+        }
+      } else {
+        output += percentEncodeNonAscii(0xFFFD)
+      }
+    }
+  }
+
+  return output
+}
+
+/**
+ * Encodes userinfo while preserving its RFC 3986 §3.2.1 literal characters.
+ * In particular, authority delimiters such as `@`, `/`, `?`, and `#` are data.
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function encodeUserinfo (input) {
+  return encodeComponent(input, isUserinfoCharacter)
+}
+
+/**
+ * Encodes query data using the RFC 3986 §3.4 grammar. A literal `#` must be
+ * escaped because it would otherwise begin the fragment component.
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function encodeQuery (input) {
+  return encodeComponent(input, isQueryFragmentCharacter)
+}
+
+/**
+ * Encodes fragment data using the RFC 3986 §3.5 grammar.
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function encodeFragment (input) {
+  return encodeComponent(input, isQueryFragmentCharacter)
+}
+
+/**
  * Escapes a component while preserving existing valid percent escapes.
  *
  * @param {string} input
@@ -568,7 +650,7 @@ function recomposeAuthority (component) {
   const uriTokens = []
 
   if (component.userinfo !== undefined) {
-    uriTokens.push(component.userinfo)
+    uriTokens.push(encodeUserinfo(component.userinfo))
     uriTokens.push('@')
   }
 
@@ -603,6 +685,9 @@ module.exports = {
   normalizePercentEncoding,
   normalizePathEncoding,
   normalizeQueryFragmentEncoding,
+  encodeUserinfo,
+  encodeQuery,
+  encodeFragment,
   escapePreservingEscapes,
   removeDotSegments,
   isIPv4,

--- a/test/component-safe-serialization.test.js
+++ b/test/component-safe-serialization.test.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+test('userinfo serialization cannot terminate the authority', (t) => {
+  const uri = fastURI.serialize({
+    scheme: 'http',
+    userinfo: 'attacker.example/',
+    host: 'trusted.example',
+    path: '/'
+  })
+
+  t.equal(uri, 'http://attacker.example%2F@trusted.example/', 'slash is encoded as userinfo data')
+
+  const reparsed = fastURI.parse(uri)
+  t.equal(reparsed.host, 'trusted.example', 'reparsing retains the supplied host')
+  t.equal(reparsed.userinfo, 'attacker.example%2F', 'encoded slash remains in userinfo')
+  t.equal(
+    fastURI.serialize({ userinfo: 'user@/?:#[]\\', host: 'example.test' }),
+    '//user%40%2F%3F:%23%5B%5D%5C@example.test',
+    'all userinfo component delimiters are encoded as data'
+  )
+  t.end()
+})
+
+test('query and fragment serialization cannot inject component delimiters', (t) => {
+  const uri = fastURI.serialize({
+    scheme: 'x',
+    path: '/resource',
+    query: 'key=value#still-query',
+    fragment: 'first#still-fragment'
+  })
+
+  t.equal(
+    uri,
+    'x:/resource?key=value%23still-query#first%23still-fragment',
+    'raw hashes are encoded within their supplied components'
+  )
+
+  const reparsed = fastURI.parse(uri)
+  t.equal(reparsed.query, 'key=value%23still-query', 'hash remains query data')
+  t.equal(reparsed.fragment, 'first%23still-fragment', 'hash remains fragment data')
+  t.end()
+})
+
+test('component serializers preserve each RFC 3986 literal character set', (t) => {
+  const unreservedAndSubDelims = "AZaz09-._~!$&'()*+,;="
+  const userinfo = unreservedAndSubDelims + ':'
+  const queryOrFragment = unreservedAndSubDelims + ':@/?'
+
+  t.equal(
+    fastURI.serialize({ userinfo, host: 'example.test' }),
+    '//' + userinfo + '@example.test',
+    'userinfo literals are preserved'
+  )
+  t.equal(
+    fastURI.serialize({ query: queryOrFragment }),
+    '?' + queryOrFragment,
+    'query literals are preserved'
+  )
+  t.equal(
+    fastURI.serialize({ fragment: queryOrFragment }),
+    '#' + queryOrFragment,
+    'fragment literals are preserved'
+  )
+  t.end()
+})
+
+test('component serializers preserve escapes and encode Unicode as UTF-8', (t) => {
+  t.equal(
+    fastURI.serialize({ userinfo: 'café/%2f%GG', host: 'example.test' }),
+    '//caf%C3%A9%2F%2F%25GG@example.test',
+    'userinfo preserves valid escapes, uppercases hex, and escapes malformed percent data'
+  )
+  t.equal(
+    fastURI.serialize({ query: '日本/%2f#%GG' }),
+    '?%E6%97%A5%E6%9C%AC/%2F%23%25GG',
+    'query uses UTF-8 and does not double encode valid escapes'
+  )
+  t.equal(
+    fastURI.serialize({ fragment: '😀/%3f#%GG' }),
+    '#%F0%9F%98%80/%3F%23%25GG',
+    'fragment uses UTF-8 and does not double encode valid escapes'
+  )
+  t.equal(
+    fastURI.serialize({ query: 'Kſ' }),
+    '?%E2%84%AA%C5%BF',
+    'Unicode characters that case-fold to ASCII are still UTF-8 encoded'
+  )
+  t.end()
+})
+
+test('parsed URI serialization remains stable', (t) => {
+  const input = 'x://user:pass@example.test/a%2Fb?x=a/b?c&y=%23#frag/a?b%23'
+  const serialized = fastURI.serialize(fastURI.parse(input))
+
+  t.equal(serialized, input, 'an already normalized parsed URI round-trips unchanged')
+  t.equal(
+    fastURI.serialize(fastURI.parse(serialized)),
+    serialized,
+    'repeated parse and serialize cycles are stable'
+  )
+  t.end()
+})


### PR DESCRIPTION
## Summary

- percent-encode structural delimiters in serialized userinfo, query, and fragment data
- preserve each component's RFC 3986 literal character set and valid escapes
- encode Unicode as UTF-8 without changing parsed URI round trips
- verify reparsing cannot move userinfo data into the host

## Validation

- focused regression: 16/16 passed
- `npm test`: 1137/1137 passed
- `npm run lint`: passed
- `npm run test:typescript`: 7/7 assertions passed
- `git diff --check`: passed
