### PR TITLE
fix: preserve WebSocket query delimiters

### DIFF
--- a/lib/schemes.js
+++ b/lib/schemes.js
@@ -113,9 +113,14 @@ function wsSerialize (wsComponent) {
 
   // reconstruct path from resource name
   if (wsComponent.resourceName) {
-    const [path, query] = wsComponent.resourceName.split('?')
+    const queryIndex = wsComponent.resourceName.indexOf('?')
+    const path = queryIndex === -1
+      ? wsComponent.resourceName
+      : wsComponent.resourceName.slice(0, queryIndex)
     wsComponent.path = (path && path !== '/' ? path : undefined)
-    wsComponent.query = query
+    wsComponent.query = queryIndex === -1
+      ? undefined
+      : wsComponent.resourceName.slice(queryIndex + 1)
     wsComponent.resourceName = undefined
   }
 

--- a/test/websocket-query-preservation.test.js
+++ b/test/websocket-query-preservation.test.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+test('WebSocket queries preserve additional question marks', (t) => {
+  for (const scheme of ['ws', 'wss']) {
+    const uri = `${scheme}://example.com/chat?a?b`
+    const truncatedURI = `${scheme}://example.com/chat?a`
+    const parsed = fastURI.parse(uri)
+
+    t.equal(parsed.resourceName, '/chat?a?b', `${scheme} parse preserves the resource name`)
+    t.equal(fastURI.serialize(parsed), uri, `${scheme} parsed components round-trip`)
+    t.equal(
+      fastURI.serialize({ scheme, host: 'example.com', resourceName: '/chat?a?b' }),
+      uri,
+      `${scheme} resource name serializes without truncation`
+    )
+    t.equal(fastURI.normalize(uri), uri, `${scheme} normalization preserves the full query`)
+    t.equal(fastURI.equal(uri, truncatedURI), false, `${scheme} equality distinguishes the full query`)
+  }
+
+  t.end()
+})


### PR DESCRIPTION
## Summary

- split WebSocket resource names at the first query delimiter only
- preserve every later `?` as query data
- add parse, serialize, normalize, and equality regressions for `ws` and `wss`

## Validation

- focused regression: 10/10 passed
- `npm test`: 1131/1131 passed
- `npm run lint`: passed
- `npm run test:typescript`: 7/7 assertions passed
- `git diff --check`: passed
