### PR TITLE
fix: validate complete URN input

### DIFF
--- a/lib/schemes.js
+++ b/lib/schemes.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { isUUID, BYTE_HEX, percentEncodeNonAscii, nonSimpleMailtoDomain } = require('./utils')
-const URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu
+const URN_REG = /^([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-./:;=@]|%[\da-f]{2})+)$/iu
 
 const supportedSchemeNames = /** @type {const} */ (['http', 'https', 'ws',
   'wss', 'urn', 'urn:uuid', 'mailto'])
@@ -132,7 +132,7 @@ function urnParse (urnComponent, options) {
     return urnComponent
   }
   const matches = urnComponent.path.match(URN_REG)
-  if (matches) {
+  if (matches && matches[0] === urnComponent.path) {
     const scheme = options.scheme || urnComponent.scheme || 'urn'
     urnComponent.nid = matches[1].toLowerCase()
     urnComponent.nss = matches[2]

--- a/test/urn-full-input.test.js
+++ b/test/urn-full-input.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+test('URN parsing validates the complete scheme-specific input', (t) => {
+  const embedded = fastURI.parse('urn:x|foo:bar')
+  t.equal(embedded.error, 'URN can not be parsed.', 'does not search for a later nid:nss substring')
+  t.equal(embedded.nid, undefined, 'does not adopt the later nid')
+  t.equal(embedded.nss, undefined, 'does not adopt the later nss')
+
+  const trailing = fastURI.parse('urn:foo:bar|ignored')
+  t.equal(trailing.error, 'URN can not be parsed.', 'rejects trailing input outside the RFC 2141 NSS grammar')
+  t.equal(trailing.nid, undefined, 'does not return an nid from a partial match')
+  t.equal(trailing.nss, undefined, 'does not return a truncated nss')
+
+  t.end()
+})
+
+test('URN parsing preserves the complete RFC 2141 NSS', (t) => {
+  const parsed = fastURI.parse('urn:foo:allowed/evil')
+  t.equal(parsed.error, undefined, 'accepts slash in an RFC 2141 NSS')
+  t.equal(parsed.nid, 'foo', 'parses the nid')
+  t.equal(parsed.nss, 'allowed/evil', 'preserves the complete NSS')
+  t.equal(fastURI.normalize('urn:foo:allowed/evil'), 'urn:foo:allowed/evil', 'normalization retains slash data')
+  t.equal(fastURI.equal('urn:foo:allowed/evil', 'urn:foo:allowed'), false, 'distinct NSS values do not compare equal')
+
+  t.end()
+})


### PR DESCRIPTION
## Summary

- anchor ordinary URN parsing to the complete scheme-specific input
- reject unmatched prefixes, suffixes, and trailing invalid data
- preserve `/` when it is valid NSS data
- add parsing, normalization, and equality regressions

## Validation

- focused regression: 11/11 passed
- `npm test`: 1132/1132 passed
- `npm run lint`: passed
- `npm run test:typescript`: 7/7 assertions passed
- `git diff --check`: passed
