### PR TITLE
fix: preserve reserved path characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, normalizeQueryFragmentEncoding, encodeQuery, encodeFragment, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require('./lib/utils')
+const { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, serializePathEncoding, normalizeQueryFragmentEncoding, encodeQuery, encodeFragment, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require('./lib/utils')
 const { SCHEMES, getSchemeHandler } = require('./lib/schemes')
 
 /**
@@ -186,13 +186,12 @@ function serialize (cmpts, opts) {
   // perform scheme specific serialization
   if (schemeHandler && schemeHandler.serialize) schemeHandler.serialize(component, options)
 
+  const hasAuthority = component.userinfo !== undefined || component.host !== undefined || component.port !== undefined
+  const pathNoScheme = !options.skipEscape && component.scheme === undefined && !hasAuthority
+
   if (component.path !== undefined) {
     if (!options.skipEscape) {
-      component.path = escapePreservingEscapes(component.path)
-
-      if (component.scheme !== undefined) {
-        component.path = component.path.split('%3A').join(':')
-      }
+      component.path = serializePathEncoding(component.path, pathNoScheme)
     } else {
       component.path = normalizePercentEncoding(component.path)
     }
@@ -219,6 +218,13 @@ function serialize (cmpts, opts) {
 
     if (!options.absolutePath && (!schemeHandler || !schemeHandler.absolutePath)) {
       s = removeDotSegments(s)
+    }
+
+    // Dot-segment removal can expose a colon that was not originally in the
+    // first segment (for example, "./a:b"). Reapply path-noscheme encoding so
+    // the serialized relative reference cannot be reparsed as a URI scheme.
+    if (pathNoScheme) {
+      s = serializePathEncoding(s, true)
     }
 
     if (

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,7 @@ const isHexPair = RegExp.prototype.test.bind(/^[\da-f]{2}$/iu)
 const isUnreserved = RegExp.prototype.test.bind(/^[\da-z\-._~]$/iu)
 
 /** @type {(value: string) => boolean} */
-const isPathCharacter = RegExp.prototype.test.bind(/^[\da-z\-._~!$&'()*+,;=:@/]$/iu)
+const isPathCharacter = RegExp.prototype.test.bind(/^[A-Za-z0-9\-._~!$&'()*+,;=:@/]$/u)
 
 /** @type {(value: string) => boolean} */
 const isQueryFragmentCharacter = RegExp.prototype.test.bind(/^[A-Za-z0-9\-._~!$&'()*+,;=:@/?]$/u)
@@ -466,6 +466,60 @@ function normalizePathEncoding (input) {
 }
 
 /**
+ * Serializes a path without rewriting reserved data. Raw RFC 3986 path
+ * characters remain literal, valid escapes are preserved and uppercased, and
+ * everything else is UTF-8 percent-encoded. In a path-noscheme, a colon in the
+ * first segment must be escaped so the result cannot be parsed as a scheme.
+ *
+ * @param {string} input
+ * @param {boolean} [pathNoScheme=false]
+ * @returns {string}
+ */
+function serializePathEncoding (input, pathNoScheme = false) {
+  let output = ''
+  let firstSegment = pathNoScheme && input[0] !== '/'
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]
+    if (ch === '%' && i + 2 < input.length) {
+      const hex = input.slice(i + 1, i + 3)
+      if (isHexPair(hex)) {
+        output += '%' + hex.toUpperCase()
+        i += 2
+        continue
+      }
+    }
+
+    if (ch === '/') {
+      firstSegment = false
+    }
+
+    if (isPathCharacter(ch) && (ch !== ':' || !firstSegment)) {
+      output += ch
+    } else {
+      const code = input.charCodeAt(i)
+      if (code < 0x80) {
+        output += BYTE_HEX[code]
+      } else if (code < 0xD800 || code > 0xDFFF) {
+        output += percentEncodeNonAscii(code)
+      } else if (code <= 0xDBFF && i + 1 < input.length) {
+        const low = input.charCodeAt(i + 1)
+        if (low >= 0xDC00 && low <= 0xDFFF) {
+          output += percentEncodeNonAscii(0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00))
+          i++
+        } else {
+          output += percentEncodeNonAscii(0xFFFD)
+        }
+      } else {
+        output += percentEncodeNonAscii(0xFFFD)
+      }
+    }
+  }
+
+  return output
+}
+
+/**
  * Normalizes the percent-encoding of a query or fragment component.
  *
  * Like `normalizePathEncoding`, but uses the query/fragment character set
@@ -684,6 +738,7 @@ module.exports = {
   reescapeHostDelimiters,
   normalizePercentEncoding,
   normalizePathEncoding,
+  serializePathEncoding,
   normalizeQueryFragmentEncoding,
   encodeUserinfo,
   encodeQuery,

--- a/test/reserved-path-normalization.test.js
+++ b/test/reserved-path-normalization.test.js
@@ -1,0 +1,109 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+const PATH_RESERVED = "!$&'()*+,;=:@/"
+
+function percentEncode (character, lowerCase) {
+  const hex = character.charCodeAt(0).toString(16).padStart(2, '0')
+  return '%' + (lowerCase ? hex : hex.toUpperCase())
+}
+
+test('normalize preserves literal and escaped reserved path characters', (t) => {
+  t.equal(
+    fastURI.normalize('http://example.com/a;b'),
+    'http://example.com/a;b',
+    'literal semicolon remains literal'
+  )
+  t.equal(
+    fastURI.normalize('http://example.com/a%3ab'),
+    'http://example.com/a%3Ab',
+    'escaped colon remains escaped and its hex is uppercased'
+  )
+
+  for (const character of PATH_RESERVED) {
+    const literal = `http://example.com/a${character}b`
+    const escaped = `http://example.com/a${percentEncode(character, true)}b`
+    const normalizedEscape = `http://example.com/a${percentEncode(character, false)}b`
+
+    t.equal(fastURI.normalize(literal), literal, `preserves literal ${character}`)
+    t.equal(fastURI.normalize(escaped), normalizedEscape, `preserves escaped ${character}`)
+  }
+
+  t.equal(
+    fastURI.normalize('http://example.com/a/./café'),
+    'http://example.com/a/caf%C3%A9',
+    'removes real dot segments and UTF-8 encodes raw non-ASCII'
+  )
+  t.equal(
+    fastURI.normalize('http://example.com/a/%2e%2e/b'),
+    'http://example.com/a/%2E%2E/b',
+    'preserves escaped dots as path data'
+  )
+  t.equal(
+    fastURI.normalize('http://example.com/Kſ'),
+    'http://example.com/%E2%84%AA%C5%BF',
+    'UTF-8 encodes Unicode characters that case-fold to ASCII'
+  )
+  t.end()
+})
+
+test('serialize uses the RFC 3986 path character set without opening escapes', (t) => {
+  const rawPath = `/a${PATH_RESERVED}b`
+  t.equal(
+    fastURI.serialize({ scheme: 'http', host: 'example.com', path: rawPath }),
+    `http://example.com${rawPath}`,
+    'keeps all legal raw path characters'
+  )
+
+  const escapedPath = Array.from(PATH_RESERVED, (character) => percentEncode(character, true)).join('')
+  const normalizedEscapedPath = Array.from(PATH_RESERVED, (character) => percentEncode(character, false)).join('')
+  t.equal(
+    fastURI.serialize({ scheme: 'http', host: 'example.com', path: '/' + escapedPath }),
+    'http://example.com/' + normalizedEscapedPath,
+    'uppercases valid escapes without decoding reserved characters'
+  )
+
+  t.equal(
+    fastURI.serialize({ scheme: 'http', host: 'example.com', path: '/a?b#c[d]' }),
+    'http://example.com/a%3Fb%23c%5Bd%5D',
+    'encodes characters that would leave the path component'
+  )
+  t.equal(
+    fastURI.serialize({ path: 'a:b/c:d' }),
+    'a%3Ab/c:d',
+    'only escapes a colon where path-noscheme requires it'
+  )
+  t.equal(
+    fastURI.serialize({ path: './a:b/c:d' }),
+    'a%3Ab/c:d',
+    'escapes a first-segment colon exposed by dot-segment removal'
+  )
+  t.equal(
+    fastURI.normalize('./a:b'),
+    'a%3Ab',
+    'normalization keeps a relative path from becoming a scheme'
+  )
+  t.equal(
+    fastURI.serialize({ path: '/Kſ' }),
+    '/%E2%84%AA%C5%BF',
+    'UTF-8 encodes Unicode characters that case-fold to ASCII'
+  )
+  t.end()
+})
+
+test('equal distinguishes escaped reserved path data from literal syntax', (t) => {
+  for (const character of PATH_RESERVED) {
+    const literal = `http://example.com/a${character}b`
+    const escaped = `http://example.com/a${percentEncode(character, false)}b`
+    t.equal(fastURI.equal(literal, escaped, {}), false, `distinguishes literal and escaped ${character}`)
+  }
+
+  t.equal(
+    fastURI.equal('./a:b', 'a:b', {}),
+    false,
+    'does not equate a relative path with an absolute URI after removing dot segments'
+  )
+  t.end()
+})


### PR DESCRIPTION
## Summary

- serialize paths with the RFC 3986 path character set
- preserve literal reserved path characters and existing reserved escapes
- keep path-noscheme colon handling, including after dot-segment removal, without rewriting encoded colons
- encode non-ASCII path data as UTF-8 without Unicode case-folding leaks
- add regressions across normalization, serialization, and equality

This is an RFC correctness fix. The associated advisory was closed because there is no demonstrated vulnerability or security-boundary impact.

## Validation

- focused path/security regression suite: 164/164 passed
- exhaustive RFC path ASCII matrix: 130/130 passed
- `npm test`: 1241/1241 passed
- `npm run lint`: passed
- `npm run test:typescript`: 7/7 assertions passed
- `git diff --check`: passed
