### PR TITLE
fix: reject malformed percent escapes

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,17 @@ function normalize (uri, options) {
  */
 function resolve (baseURI, relativeURI, options) {
   const schemelessOptions = options ? Object.assign({ scheme: 'null' }, options) : { scheme: 'null' }
-  const { parsed: baseParsed, malformedAuthorityOrPort: baseMalformed } = parseWithStatus(baseURI, schemelessOptions)
-  const { parsed: relativeParsed, malformedAuthorityOrPort: relativeMalformed } = parseWithStatus(relativeURI, schemelessOptions)
-  if (baseMalformed || relativeMalformed) {
+  const {
+    parsed: baseParsed,
+    malformedAuthorityOrPort: baseMalformed,
+    malformedPercentEncoding: baseMalformedPercentEncoding
+  } = parseWithStatus(baseURI, schemelessOptions)
+  const {
+    parsed: relativeParsed,
+    malformedAuthorityOrPort: relativeMalformed,
+    malformedPercentEncoding: relativeMalformedPercentEncoding
+  } = parseWithStatus(relativeURI, schemelessOptions)
+  if (baseMalformed || relativeMalformed || baseMalformedPercentEncoding || relativeMalformedPercentEncoding) {
     throw new Error(baseParsed.error || relativeParsed.error || 'URI is malformed.')
   }
   const resolved = resolveComponent(baseParsed, relativeParsed, schemelessOptions, true)
@@ -268,9 +276,46 @@ function getParseError (parsed, matches) {
 }
 
 /**
+ * Checks percent syntax without decoding the represented octets. RFC 3986
+ * percent-encoding is byte-oriented, so sequences such as `%FF` are valid even
+ * though they are not independently valid UTF-8.
+ *
+ * @param {string|undefined} component
+ * @returns {boolean}
+ */
+function hasMalformedPercentEncoding (component) {
+  if (component === undefined) return false
+
+  let percent = component.indexOf('%')
+  while (percent !== -1) {
+    if (percent + 2 >= component.length || !/^[\da-f]{2}$/iu.test(component.slice(percent + 1, percent + 3))) {
+      return true
+    }
+    percent = component.indexOf('%', percent + 3)
+  }
+
+  return false
+}
+
+/**
+ * @param {RegExpMatchArray} matches
+ * @returns {boolean}
+ */
+function hasMalformedComponentPercentEncoding (matches) {
+  // Bracketed IP literals use a raw "%" as the zone separator for historical
+  // compatibility. Their parsing is intentionally left to normalizeIPv6.
+  const host = matches[4]
+  return hasMalformedPercentEncoding(matches[3]) ||
+    (host !== undefined && !(host[0] === '[' && host[host.length - 1] === ']') && hasMalformedPercentEncoding(host)) ||
+    hasMalformedPercentEncoding(matches[6]) ||
+    hasMalformedPercentEncoding(matches[7]) ||
+    hasMalformedPercentEncoding(matches[8])
+}
+
+/**
  * @param {string} uri
  * @param {import('./types/index').Options} [opts]
- * @returns {{ parsed: import('./types/index').URIComponent, malformedAuthorityOrPort: boolean }}
+ * @returns {{ parsed: import('./types/index').URIComponent, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean }}
  */
 function parseWithStatus (uri, opts) {
   const options = Object.assign({}, opts)
@@ -286,6 +331,7 @@ function parseWithStatus (uri, opts) {
   }
 
   let malformedAuthorityOrPort = false
+  let malformedPercentEncoding = false
 
   let isIP = false
   if (options.reference === 'suffix') {
@@ -342,6 +388,11 @@ function parseWithStatus (uri, opts) {
     parsed.path = matches[6] || ''
     parsed.query = matches[7]
     parsed.fragment = matches[8]
+
+    malformedPercentEncoding = hasMalformedComponentPercentEncoding(matches)
+    if (malformedPercentEncoding) {
+      parsed.error = parsed.error || 'URI contains malformed percent-encoding.'
+    }
 
     // fix port number
     if (isNaN(parsed.port)) {
@@ -423,7 +474,7 @@ function parseWithStatus (uri, opts) {
   } else {
     parsed.error = parsed.error || 'URI can not be parsed.'
   }
-  return { parsed, malformedAuthorityOrPort }
+  return { parsed, malformedAuthorityOrPort, malformedPercentEncoding }
 }
 
 /**
@@ -447,13 +498,14 @@ function normalizeString (uri, opts) {
 /**
  * @param {string} uri
  * @param {import('./types/index').Options} [opts]
- * @returns {{ normalized: string, malformedAuthorityOrPort: boolean }}
+ * @returns {{ normalized: string, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean }}
  */
 function normalizeStringWithStatus (uri, opts) {
-  const { parsed, malformedAuthorityOrPort } = parseWithStatus(uri, opts)
+  const { parsed, malformedAuthorityOrPort, malformedPercentEncoding } = parseWithStatus(uri, opts)
   return {
-    normalized: malformedAuthorityOrPort ? uri : serialize(parsed, opts),
-    malformedAuthorityOrPort
+    normalized: malformedAuthorityOrPort || malformedPercentEncoding ? uri : serialize(parsed, opts),
+    malformedAuthorityOrPort,
+    malformedPercentEncoding
   }
 }
 
@@ -464,8 +516,8 @@ function normalizeStringWithStatus (uri, opts) {
  */
 function normalizeComparableURI (uri, opts) {
   if (typeof uri === 'string') {
-    const { normalized, malformedAuthorityOrPort } = normalizeStringWithStatus(uri, opts)
-    return malformedAuthorityOrPort ? undefined : normalized
+    const { normalized, malformedAuthorityOrPort, malformedPercentEncoding } = normalizeStringWithStatus(uri, opts)
+    return malformedAuthorityOrPort || malformedPercentEncoding ? undefined : normalized
   }
 
   if (typeof uri === 'object') {

--- a/test/malformed-percent.test.js
+++ b/test/malformed-percent.test.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+const MALFORMED_PERCENT_ERROR = 'URI contains malformed percent-encoding.'
+
+const malformedComponents = [
+  ['path', 'x://example.test/a%'],
+  ['path with one trailing hex digit', 'x://example.test/a%2'],
+  ['path with non-hex digits', 'x://example.test/a%GG'],
+  ['host', 'x://exa%mple.test/path'],
+  ['userinfo', 'x://us%er@example.test/path'],
+  ['query', 'x://example.test/path?q=%G0'],
+  ['fragment', 'x://example.test/path#frag%1']
+]
+
+test('parse reports malformed percent syntax in generic URI components', (t) => {
+  for (const [component, uri] of malformedComponents) {
+    t.equal(fastURI.parse(uri).error, MALFORMED_PERCENT_ERROR, component)
+  }
+  t.end()
+})
+
+test('normalize preserves malformed percent input unchanged', (t) => {
+  for (const [component, uri] of malformedComponents) {
+    t.equal(fastURI.normalize(uri), uri, component)
+  }
+  t.end()
+})
+
+test('equal does not equate malformed input with repaired valid input', (t) => {
+  const cases = [
+    ['x://example.test/a%', 'x://example.test/a%25'],
+    ['x://exa%mple.test/path', 'x://exa%25mple.test/path'],
+    ['x://us%er@example.test/path', 'x://us%25er@example.test/path'],
+    ['x://example.test/path?q=%', 'x://example.test/path?q=%25'],
+    ['x://example.test/path#%', 'x://example.test/path#%25']
+  ]
+
+  for (const [malformed, repaired] of cases) {
+    t.equal(fastURI.equal(malformed, repaired, {}), false, malformed)
+  }
+  t.end()
+})
+
+test('resolve rejects malformed percent syntax in either input', (t) => {
+  t.throws(
+    () => fastURI.resolve('x://example.test/base%', 'child'),
+    /URI contains malformed percent-encoding\./,
+    'malformed base'
+  )
+  t.throws(
+    () => fastURI.resolve('x://example.test/base', 'child%'),
+    /URI contains malformed percent-encoding\./,
+    'malformed relative reference'
+  )
+  t.end()
+})
+
+test('valid percent octets remain valid without UTF-8 validation', (t) => {
+  const uri = '/%ff?q=%80#%fe'
+  const parsed = fastURI.parse(uri)
+
+  t.equal(parsed.error, undefined, 'non-UTF-8 octets are valid percent syntax')
+  t.equal(parsed.path, '/%FF', 'path octet is preserved and hex is uppercased')
+  t.equal(parsed.query, 'q=%80', 'query octet is preserved')
+  t.equal(parsed.fragment, '%FE', 'fragment octet is preserved and hex is uppercased')
+  t.equal(fastURI.normalize(uri), '/%FF?q=%80#%FE', 'normalization preserves the octets')
+
+  const allGenericComponents = fastURI.parse('x://u%2f@exa%2fmple.test/%2f?q=%2f#%2f')
+  t.equal(allGenericComponents.error, undefined, 'valid escapes are accepted in every generic component')
+
+  const ipv6Zone = fastURI.parse('//[2001:db8::7%en0]')
+  t.equal(ipv6Zone.error, undefined, 'historically accepted raw IPv6 zone separator is unchanged')
+  t.end()
+})


### PR DESCRIPTION
## Summary

- detect malformed percent triplets in generic URI components without decoding bytes
- report malformed syntax through `parse().error`
- preserve malformed string input during normalization
- make equality fail safely and resolution reject malformed input
- retain valid non-UTF-8 percent octets

## Validation

- focused regression: 28/28 passed
- `npm test`: 1149/1149 passed
- `npm run lint`: passed
- `npm run test:typescript`: 7/7 assertions passed
- `git diff --check`: passed
