### PR TITLE
fix: handle malformed URNs safely

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ function normalize (uri, options) {
  */
 function resolve (baseURI, relativeURI, options) {
   const schemelessOptions = options ? Object.assign({ scheme: 'null' }, options) : { scheme: 'null' }
-  const { parsed: baseParsed, malformedAuthorityOrPort: baseMalformed } = parseWithStatus(baseURI, schemelessOptions)
-  const { parsed: relativeParsed, malformedAuthorityOrPort: relativeMalformed } = parseWithStatus(relativeURI, schemelessOptions)
-  if (baseMalformed || relativeMalformed) {
+  const { parsed: baseParsed, malformedAuthorityOrPort: baseMalformed, malformedSchemeSpecific: baseMalformedSchemeSpecific } = parseWithStatus(baseURI, schemelessOptions)
+  const { parsed: relativeParsed, malformedAuthorityOrPort: relativeMalformed, malformedSchemeSpecific: relativeMalformedSchemeSpecific } = parseWithStatus(relativeURI, schemelessOptions)
+  if (baseMalformed || relativeMalformed || baseMalformedSchemeSpecific || relativeMalformedSchemeSpecific) {
     throw new Error(baseParsed.error || relativeParsed.error || 'URI is malformed.')
   }
   const resolved = resolveComponent(baseParsed, relativeParsed, schemelessOptions, true)
@@ -270,7 +270,7 @@ function getParseError (parsed, matches) {
 /**
  * @param {string} uri
  * @param {import('./types/index').Options} [opts]
- * @returns {{ parsed: import('./types/index').URIComponent, malformedAuthorityOrPort: boolean }}
+ * @returns {{ parsed: import('./types/index').URIComponent, malformedAuthorityOrPort: boolean, malformedSchemeSpecific: boolean }}
  */
 function parseWithStatus (uri, opts) {
   const options = Object.assign({}, opts)
@@ -286,6 +286,7 @@ function parseWithStatus (uri, opts) {
   }
 
   let malformedAuthorityOrPort = false
+  let malformedSchemeSpecific = false
 
   let isIP = false
   if (options.reference === 'suffix') {
@@ -419,11 +420,14 @@ function parseWithStatus (uri, opts) {
     // perform scheme specific parsing
     if (schemeHandler && schemeHandler.parse) {
       schemeHandler.parse(parsed, options)
+      if (schemeHandler === SCHEMES.urn && parsed.nid === undefined) {
+        malformedSchemeSpecific = true
+      }
     }
   } else {
     parsed.error = parsed.error || 'URI can not be parsed.'
   }
-  return { parsed, malformedAuthorityOrPort }
+  return { parsed, malformedAuthorityOrPort, malformedSchemeSpecific }
 }
 
 /**
@@ -447,13 +451,14 @@ function normalizeString (uri, opts) {
 /**
  * @param {string} uri
  * @param {import('./types/index').Options} [opts]
- * @returns {{ normalized: string, malformedAuthorityOrPort: boolean }}
+ * @returns {{ normalized: string, malformedAuthorityOrPort: boolean, malformedSchemeSpecific: boolean }}
  */
 function normalizeStringWithStatus (uri, opts) {
-  const { parsed, malformedAuthorityOrPort } = parseWithStatus(uri, opts)
+  const { parsed, malformedAuthorityOrPort, malformedSchemeSpecific } = parseWithStatus(uri, opts)
   return {
-    normalized: malformedAuthorityOrPort ? uri : serialize(parsed, opts),
-    malformedAuthorityOrPort
+    normalized: malformedAuthorityOrPort || malformedSchemeSpecific ? uri : serialize(parsed, opts),
+    malformedAuthorityOrPort,
+    malformedSchemeSpecific
   }
 }
 
@@ -464,8 +469,8 @@ function normalizeStringWithStatus (uri, opts) {
  */
 function normalizeComparableURI (uri, opts) {
   if (typeof uri === 'string') {
-    const { normalized, malformedAuthorityOrPort } = normalizeStringWithStatus(uri, opts)
-    return malformedAuthorityOrPort ? undefined : normalized
+    const { normalized, malformedAuthorityOrPort, malformedSchemeSpecific } = normalizeStringWithStatus(uri, opts)
+    return malformedAuthorityOrPort || malformedSchemeSpecific ? undefined : normalized
   }
 
   if (typeof uri === 'object') {

--- a/test/equal.test.js
+++ b/test/equal.test.js
@@ -66,9 +66,7 @@ test('URN Equals', (t) => {
 
   runTest(t, suite)
 
-  t.throws(() => {
-    fn('urn:', 'urn:FOO:a123,456')
-  }, 'URN without nid cannot be serialized')
+  t.equal(fn('urn:', 'urn:FOO:a123,456'), false, 'malformed URN fails equality safely')
 
   t.end()
 })

--- a/test/malformed-urn.test.js
+++ b/test/malformed-urn.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+const malformedURNs = [
+  'urn:',
+  'URN:',
+  'urn:foo',
+  'urn::foo',
+  'urn:foo:'
+]
+
+test('parse reports malformed ordinary URNs', (t) => {
+  for (const uri of malformedURNs) {
+    t.match(fastURI.parse(uri).error, /^URN can not be parsed\.?$/, uri)
+  }
+  t.end()
+})
+
+test('normalize preserves malformed ordinary URNs without throwing', (t) => {
+  for (const uri of malformedURNs) {
+    t.doesNotThrow(() => fastURI.normalize(uri), `${uri} does not throw`)
+    t.equal(fastURI.normalize(uri), uri, `${uri} is preserved`)
+  }
+  t.equal(
+    fastURI.normalize('urn:foo', { reference: 'relative' }),
+    'urn:foo',
+    'an earlier parse error does not hide the missing URN nid'
+  )
+  t.end()
+})
+
+test('equal fails safely for malformed ordinary URNs', (t) => {
+  for (const uri of malformedURNs) {
+    t.equal(fastURI.equal(uri, uri, {}), false, `${uri} is not equal to itself as malformed input`)
+    t.equal(fastURI.equal(uri, 'urn:foo:bar', {}), false, `${uri} is not equal to a valid URN`)
+  }
+  t.end()
+})
+
+test('valid URNs retain their existing behavior', (t) => {
+  t.equal(fastURI.normalize('URN:FOO:a123,456'), 'urn:foo:a123,456')
+  t.equal(fastURI.equal('urn:foo:a123,456', 'URN:FOO:a123,456', {}), true)
+  t.equal(fastURI.resolve('uri://base/', 'urn:'), 'urn:', 'default resolve behavior is unchanged')
+  t.end()
+})


### PR DESCRIPTION
## Summary

- track malformed ordinary URNs before serialization
- preserve malformed URN strings during normalization instead of throwing
- make equality return `false` safely for malformed URNs
- retain existing behavior for valid URNs and unrelated scheme handlers

## Validation

- focused regression plus equality suite: 105/105 passed
- `npm test`: 1150/1150 passed
- `npm run lint`: passed
- `npm run test:typescript`: 7/7 assertions passed
- `git diff --check`: passed
