### PR TITLE
fix: preserve URI component case in equality

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,36 +119,10 @@ function resolveComponent (base, relative, options, skipNormalization) {
  * @returns {boolean}
  */
 function equal (uriA, uriB, options) {
-  const schemeA = getEffectiveScheme(uriA, options)
-  const schemeB = getEffectiveScheme(uriB, options)
   const normalizedA = normalizeComparableURI(uriA, options)
   const normalizedB = normalizeComparableURI(uriB, options)
 
-  if (schemeA === 'mailto' || schemeB === 'mailto') {
-    return schemeA === schemeB && normalizedA !== undefined && normalizedA === normalizedB
-  }
-
-  return normalizedA !== undefined && normalizedB !== undefined && normalizedA.toLowerCase() === normalizedB.toLowerCase()
-}
-
-const SCHEME_PREFIX = /^([^#/:?]+):/u
-
-/**
- * @param {import ('./types/index').URIComponent|string} uri
- * @param {import('./types/index').Options} [options]
- * @returns {string|undefined}
- */
-function getEffectiveScheme (uri, options) {
-  if (options && options.scheme) {
-    return String(options.scheme).toLowerCase()
-  }
-  if (typeof uri === 'object' && uri.scheme) {
-    return String(uri.scheme).toLowerCase()
-  }
-  if (typeof uri === 'string') {
-    const match = uri.match(SCHEME_PREFIX)
-    return match ? match[1].toLowerCase() : undefined
-  }
+  return normalizedA !== undefined && normalizedB !== undefined && normalizedA === normalizedB
 }
 
 /**
@@ -515,14 +489,13 @@ function normalizeStringWithStatus (uri, opts) {
  * @returns {string|undefined}
  */
 function normalizeComparableURI (uri, opts) {
-  if (typeof uri === 'string') {
-    const { normalized, malformedAuthorityOrPort, malformedPercentEncoding } = normalizeStringWithStatus(uri, opts)
-    return malformedAuthorityOrPort || malformedPercentEncoding ? undefined : normalized
+  if (typeof uri !== 'string' && typeof uri !== 'object') {
+    return undefined
   }
 
-  if (typeof uri === 'object') {
-    return serialize(uri, opts)
-  }
+  const value = typeof uri === 'string' ? uri : serialize(uri, opts)
+  const { normalized, malformedAuthorityOrPort, malformedPercentEncoding } = normalizeStringWithStatus(value, opts)
+  return malformedAuthorityOrPort || malformedPercentEncoding ? undefined : normalized
 }
 
 const fastUri = {

--- a/test/equal.test.js
+++ b/test/equal.test.js
@@ -21,6 +21,12 @@ test('URI Equals', (t) => {
   t.end()
 })
 
+test('URI Equals rejects malformed object input even when identical', (t) => {
+  const malformed = { scheme: 'http', host: 'example.com', port: 99999, path: '/x' }
+  t.equal(fn(malformed, malformed), false)
+  t.end()
+})
+
 test('URI Equals preserves case-sensitive components', (t) => {
   const suite = [
     { pair: ['http://example.com/Admin', 'http://example.com/admin'], result: false },

--- a/test/equal.test.js
+++ b/test/equal.test.js
@@ -21,6 +21,30 @@ test('URI Equals', (t) => {
   t.end()
 })
 
+test('URI Equals preserves case-sensitive components', (t) => {
+  const suite = [
+    { pair: ['http://example.com/Admin', 'http://example.com/admin'], result: false },
+    { pair: ['http://example.com/?token=SECRET', 'http://example.com/?token=secret'], result: false },
+    { pair: ['http://example.com/#Section', 'http://example.com/#section'], result: false },
+    { pair: ['http://User@example.com/', 'http://user@example.com/'], result: false },
+    { pair: ['urn:foo:CaseSensitive', 'urn:foo:casesensitive'], result: false },
+    { pair: ['ws://example.com/Chat', 'ws://example.com/chat'], result: false },
+    { pair: ['ws://example.com/?token=SECRET', 'ws://example.com/?token=secret'], result: false },
+    { pair: [{ scheme: 'http', host: 'example.com', path: '/Admin' }, { scheme: 'http', host: 'example.com', path: '/admin' }], result: false }
+  ]
+  runTest(t, suite)
+  t.end()
+})
+
+test('URI Equals folds normalized scheme and host case', (t) => {
+  const suite = [
+    { pair: ['HTTP://EXAMPLE.COM/resource', 'http://example.com/resource'], result: true },
+    { pair: [{ scheme: 'HTTP', host: 'EXAMPLE.COM', path: '/resource' }, { scheme: 'http', host: 'example.com', path: '/resource' }], result: true }
+  ]
+  runTest(t, suite)
+  t.end()
+})
+
 //   test('IRI Equals', (t) => {
 //     // example from RFC 3987
 //     t.equal(URI.equal('example://a/b/c/%7Bfoo%7D/ros\xE9', 'eXAMPLE://a/./b/../b/%63/%7bfoo%7d/ros%C3%A9', IRI_OPTION), true)


### PR DESCRIPTION
Correct `equal()` so normalization controls case folding instead of lowercasing the complete URI. This preserves case-sensitive path, query, fragment, userinfo, WebSocket resource, and URN NSS data while retaining scheme, host, and scheme-specific normalization.

This is a correctness and defense-in-depth fix for GHSA-wwpg-6wxh-phxg. No concrete security boundary bypass has been established, so it should not be characterized as a vulnerability.
