### PR TITLE
fix: validate URI scheme grammar

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,14 +29,16 @@ function resolve (baseURI, relativeURI, options) {
   const {
     parsed: baseParsed,
     malformedAuthorityOrPort: baseMalformed,
-    malformedPercentEncoding: baseMalformedPercentEncoding
+    malformedPercentEncoding: baseMalformedPercentEncoding,
+    malformedScheme: baseMalformedScheme
   } = parseWithStatus(baseURI, schemelessOptions)
   const {
     parsed: relativeParsed,
     malformedAuthorityOrPort: relativeMalformed,
-    malformedPercentEncoding: relativeMalformedPercentEncoding
+    malformedPercentEncoding: relativeMalformedPercentEncoding,
+    malformedScheme: relativeMalformedScheme
   } = parseWithStatus(relativeURI, schemelessOptions)
-  if (baseMalformed || relativeMalformed || baseMalformedPercentEncoding || relativeMalformedPercentEncoding) {
+  if (baseMalformed || relativeMalformed || baseMalformedPercentEncoding || relativeMalformedPercentEncoding || baseMalformedScheme || relativeMalformedScheme) {
     throw new Error(baseParsed.error || relativeParsed.error || 'URI is malformed.')
   }
   const resolved = resolveComponent(baseParsed, relativeParsed, schemelessOptions, true)
@@ -131,7 +133,9 @@ function equal (uriA, uriB, options) {
   return normalizedA !== undefined && normalizedB !== undefined && normalizedA.toLowerCase() === normalizedB.toLowerCase()
 }
 
-const SCHEME_PREFIX = /^([^#/:?]+):/u
+const SCHEME = /^[A-Za-z][A-Za-z\d+.-]*$/
+const SCHEME_PREFIX = /^([A-Za-z][A-Za-z\d+.-]*):/
+const SCHEME_CANDIDATE = /^([^#/:?]*):/u
 
 /**
  * @param {import ('./types/index').URIComponent|string} uri
@@ -243,7 +247,7 @@ function serialize (cmpts, opts) {
   return uriTokens.join('')
 }
 
-const URI_PARSE = /^(?:([^#/:?]+):)?(?:\/\/((?:([^#/?@]*)@)?(\[[^#/?\]]+\]|[^#/:?]*)(?::(\d*))?))?([^#?]*)(?:\?([^#]*))?(?:#((?:.|[\n\r])*))?/u
+const URI_PARSE = /^(?:([A-Za-z][A-Za-z\d+.-]*):)?(?:\/\/((?:([^#/?@]*)@)?(\[[^#/?\]]+\]|[^#/:?]*)(?::(\d*))?))?([^#?]*)(?:\?([^#]*))?(?:#((?:.|[\n\r])*))?/u
 
 // Captures the authority component (between "//" and the next "/", "?" or "#"),
 // with or without a scheme prefix, for the literal-backslash rejection below.
@@ -315,7 +319,7 @@ function hasMalformedComponentPercentEncoding (matches) {
 /**
  * @param {string} uri
  * @param {import('./types/index').Options} [opts]
- * @returns {{ parsed: import('./types/index').URIComponent, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean }}
+ * @returns {{ parsed: import('./types/index').URIComponent, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean, malformedScheme: boolean }}
  */
 function parseWithStatus (uri, opts) {
   const options = Object.assign({}, opts)
@@ -332,6 +336,7 @@ function parseWithStatus (uri, opts) {
 
   let malformedAuthorityOrPort = false
   let malformedPercentEncoding = false
+  let malformedScheme = false
 
   let isIP = false
   if (options.reference === 'suffix') {
@@ -375,6 +380,12 @@ function parseWithStatus (uri, opts) {
         malformedAuthorityOrPort = true
       }
     }
+  }
+
+  const schemeCandidate = uri.match(SCHEME_CANDIDATE)
+  if (schemeCandidate !== null && !SCHEME.test(schemeCandidate[1])) {
+    parsed.error = parsed.error || 'URI scheme is malformed.'
+    malformedScheme = true
   }
 
   const matches = uri.match(URI_PARSE)
@@ -449,9 +460,6 @@ function parseWithStatus (uri, opts) {
 
     if (!schemeHandler || (schemeHandler && !schemeHandler.skipNormalize)) {
       if (uri.indexOf('%') !== -1) {
-        if (parsed.scheme !== undefined) {
-          parsed.scheme = unescape(parsed.scheme)
-        }
         if (parsed.host !== undefined) {
           parsed.host = reescapeHostDelimiters(unescape(parsed.host), isIP)
         }
@@ -474,7 +482,7 @@ function parseWithStatus (uri, opts) {
   } else {
     parsed.error = parsed.error || 'URI can not be parsed.'
   }
-  return { parsed, malformedAuthorityOrPort, malformedPercentEncoding }
+  return { parsed, malformedAuthorityOrPort, malformedPercentEncoding, malformedScheme }
 }
 
 /**
@@ -498,14 +506,15 @@ function normalizeString (uri, opts) {
 /**
  * @param {string} uri
  * @param {import('./types/index').Options} [opts]
- * @returns {{ normalized: string, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean }}
+ * @returns {{ normalized: string, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean, malformedScheme: boolean }}
  */
 function normalizeStringWithStatus (uri, opts) {
-  const { parsed, malformedAuthorityOrPort, malformedPercentEncoding } = parseWithStatus(uri, opts)
+  const { parsed, malformedAuthorityOrPort, malformedPercentEncoding, malformedScheme } = parseWithStatus(uri, opts)
   return {
-    normalized: malformedAuthorityOrPort || malformedPercentEncoding ? uri : serialize(parsed, opts),
+    normalized: malformedAuthorityOrPort || malformedPercentEncoding || malformedScheme ? uri : serialize(parsed, opts),
     malformedAuthorityOrPort,
-    malformedPercentEncoding
+    malformedPercentEncoding,
+    malformedScheme
   }
 }
 
@@ -516,8 +525,8 @@ function normalizeStringWithStatus (uri, opts) {
  */
 function normalizeComparableURI (uri, opts) {
   if (typeof uri === 'string') {
-    const { normalized, malformedAuthorityOrPort, malformedPercentEncoding } = normalizeStringWithStatus(uri, opts)
-    return malformedAuthorityOrPort || malformedPercentEncoding ? undefined : normalized
+    const { normalized, malformedAuthorityOrPort, malformedPercentEncoding, malformedScheme } = normalizeStringWithStatus(uri, opts)
+    return malformedAuthorityOrPort || malformedPercentEncoding || malformedScheme ? undefined : normalized
   }
 
   if (typeof uri === 'object') {

--- a/test/scheme-validation.test.js
+++ b/test/scheme-validation.test.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+const MALFORMED_SCHEME_ERROR = 'URI scheme is malformed.'
+
+const malformedSchemes = [
+  '%4Aavascript:1',
+  '1http://example.com/',
+  '+foo:value',
+  '.foo:value',
+  'foo_bar:value',
+  'foo%2Bbar:value',
+  'éxample:value',
+  'Kttp://example.com/',
+  'ſcheme:value',
+  ':value'
+]
+
+test('parse accepts only the RFC 3986 scheme grammar', (t) => {
+  const validSchemes = [
+    ['a:value', 'a'],
+    ['HTTP://example.com/', 'http'],
+    ['a1+.-:value', 'a1+.-']
+  ]
+
+  for (const [uri, scheme] of validSchemes) {
+    const parsed = fastURI.parse(uri)
+    t.equal(parsed.error, undefined, uri)
+    t.equal(parsed.scheme, scheme, uri + ' scheme')
+  }
+
+  for (const uri of malformedSchemes) {
+    const parsed = fastURI.parse(uri)
+    t.equal(parsed.error, MALFORMED_SCHEME_ERROR, uri)
+    t.equal(parsed.scheme, undefined, uri + ' has no scheme')
+  }
+  t.end()
+})
+
+test('parse never percent-decodes a would-be scheme', (t) => {
+  const parsed = fastURI.parse('%4Aavascript:1')
+
+  t.equal(parsed.error, MALFORMED_SCHEME_ERROR, 'encoded first character is rejected')
+  t.equal(parsed.scheme, undefined, 'encoded text does not become a scheme')
+  t.end()
+})
+
+test('normalize preserves malformed scheme input unchanged', (t) => {
+  for (const uri of malformedSchemes) {
+    t.equal(fastURI.normalize(uri), uri, uri)
+  }
+  t.end()
+})
+
+test('equal returns false for malformed schemes', (t) => {
+  t.equal(fastURI.equal('%4Aavascript:1', 'javascript:1'), false, 'encoded scheme differs from valid scheme')
+  t.equal(fastURI.equal('1http://example.com/', '1http://example.com/'), false, 'malformed input is not equal to itself')
+  t.end()
+})
+
+test('resolve rejects malformed schemes in either input', (t) => {
+  t.throws(
+    () => fastURI.resolve('1http://example.com/', 'child'),
+    /URI scheme is malformed\./,
+    'malformed base'
+  )
+  t.throws(
+    () => fastURI.resolve('https://example.com/', '%4Aavascript:1'),
+    /URI scheme is malformed\./,
+    'malformed relative reference'
+  )
+  t.end()
+})


### PR DESCRIPTION
## Summary

- validate parsed schemes against the ASCII grammar from RFC 3986 §3.1
- stop percent-decoding scheme text
- preserve malformed scheme input during normalization, reject it during equality checks, and throw during resolution
- add coverage for percent-encoded, invalid-leading-character, invalid-character, and Unicode case-folding forms

This addresses the behavior reported in GHSA-9pcr-hcx9-jj65 as an RFC compliance bug. No supported security-sensitive execution or navigation flow is involved.

## Tests

- `npm test`
- `npm run lint`
- `npm run test:typescript`
