### PR TITLE
fix: preserve malformed URN input

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,14 +29,23 @@ function resolve (baseURI, relativeURI, options) {
   const {
     parsed: baseParsed,
     malformedAuthorityOrPort: baseMalformed,
-    malformedPercentEncoding: baseMalformedPercentEncoding
+    malformedPercentEncoding: baseMalformedPercentEncoding,
+    malformedSchemeSpecific: baseMalformedSchemeSpecific
   } = parseWithStatus(baseURI, schemelessOptions)
   const {
     parsed: relativeParsed,
     malformedAuthorityOrPort: relativeMalformed,
-    malformedPercentEncoding: relativeMalformedPercentEncoding
+    malformedPercentEncoding: relativeMalformedPercentEncoding,
+    malformedSchemeSpecific: relativeMalformedSchemeSpecific
   } = parseWithStatus(relativeURI, schemelessOptions)
-  if (baseMalformed || relativeMalformed || baseMalformedPercentEncoding || relativeMalformedPercentEncoding) {
+  if (
+    baseMalformed ||
+    relativeMalformed ||
+    baseMalformedPercentEncoding ||
+    relativeMalformedPercentEncoding ||
+    baseMalformedSchemeSpecific ||
+    relativeMalformedSchemeSpecific
+  ) {
     throw new Error(baseParsed.error || relativeParsed.error || 'URI is malformed.')
   }
   const resolved = resolveComponent(baseParsed, relativeParsed, schemelessOptions, true)
@@ -295,7 +304,7 @@ function hasMalformedComponentPercentEncoding (matches) {
 /**
  * @param {string} uri
  * @param {import('./types/index').Options} [opts]
- * @returns {{ parsed: import('./types/index').URIComponent, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean }}
+ * @returns {{ parsed: import('./types/index').URIComponent, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean, malformedSchemeSpecific: boolean }}
  */
 function parseWithStatus (uri, opts) {
   const options = Object.assign({}, opts)
@@ -312,6 +321,7 @@ function parseWithStatus (uri, opts) {
 
   let malformedAuthorityOrPort = false
   let malformedPercentEncoding = false
+  let malformedSchemeSpecific = false
 
   let isIP = false
   if (options.reference === 'suffix') {
@@ -450,11 +460,14 @@ function parseWithStatus (uri, opts) {
     // perform scheme specific parsing
     if (schemeHandler && schemeHandler.parse) {
       schemeHandler.parse(parsed, options)
+      if (schemeHandler === SCHEMES.urn && parsed.nid === undefined) {
+        malformedSchemeSpecific = true
+      }
     }
   } else {
     parsed.error = parsed.error || 'URI can not be parsed.'
   }
-  return { parsed, malformedAuthorityOrPort, malformedPercentEncoding }
+  return { parsed, malformedAuthorityOrPort, malformedPercentEncoding, malformedSchemeSpecific }
 }
 
 /**
@@ -478,14 +491,15 @@ function normalizeString (uri, opts) {
 /**
  * @param {string} uri
  * @param {import('./types/index').Options} [opts]
- * @returns {{ normalized: string, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean }}
+ * @returns {{ normalized: string, malformedAuthorityOrPort: boolean, malformedPercentEncoding: boolean, malformedSchemeSpecific: boolean }}
  */
 function normalizeStringWithStatus (uri, opts) {
-  const { parsed, malformedAuthorityOrPort, malformedPercentEncoding } = parseWithStatus(uri, opts)
+  const { parsed, malformedAuthorityOrPort, malformedPercentEncoding, malformedSchemeSpecific } = parseWithStatus(uri, opts)
   return {
-    normalized: malformedAuthorityOrPort || malformedPercentEncoding ? uri : serialize(parsed, opts),
+    normalized: malformedAuthorityOrPort || malformedPercentEncoding || malformedSchemeSpecific ? uri : serialize(parsed, opts),
     malformedAuthorityOrPort,
-    malformedPercentEncoding
+    malformedPercentEncoding,
+    malformedSchemeSpecific
   }
 }
 
@@ -500,8 +514,8 @@ function normalizeComparableURI (uri, opts) {
   }
 
   const value = typeof uri === 'string' ? uri : serialize(uri, opts)
-  const { normalized, malformedAuthorityOrPort, malformedPercentEncoding } = normalizeStringWithStatus(value, opts)
-  return malformedAuthorityOrPort || malformedPercentEncoding ? undefined : normalized
+  const { normalized, malformedAuthorityOrPort, malformedPercentEncoding, malformedSchemeSpecific } = normalizeStringWithStatus(value, opts)
+  return malformedAuthorityOrPort || malformedPercentEncoding || malformedSchemeSpecific ? undefined : normalized
 }
 
 const fastUri = {

--- a/test/equal.test.js
+++ b/test/equal.test.js
@@ -96,9 +96,7 @@ test('URN Equals', (t) => {
 
   runTest(t, suite)
 
-  t.throws(() => {
-    fn('urn:', 'urn:FOO:a123,456')
-  }, 'URN without nid cannot be serialized')
+  t.equal(fn('urn:', 'urn:FOO:a123,456'), false, 'malformed URN fails equality safely')
 
   t.end()
 })

--- a/test/malformed-urn.test.js
+++ b/test/malformed-urn.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const test = require('tape')
+const fastURI = require('..')
+
+const malformedURNs = [
+  'urn:',
+  'URN:',
+  'urn:foo',
+  'urn::foo',
+  'urn:foo:',
+  'urn:%66oo:bar'
+]
+
+test('parse reports malformed ordinary URNs', (t) => {
+  for (const uri of malformedURNs) {
+    t.match(fastURI.parse(uri).error, /^URN can not be parsed\.?$/, uri)
+  }
+  t.end()
+})
+
+test('normalize preserves malformed ordinary URNs without throwing', (t) => {
+  for (const uri of malformedURNs) {
+    t.doesNotThrow(() => fastURI.normalize(uri), `${uri} does not throw`)
+    t.equal(fastURI.normalize(uri), uri, `${uri} is preserved`)
+  }
+  t.equal(
+    fastURI.normalize('urn:foo', { reference: 'relative' }),
+    'urn:foo',
+    'an earlier parse error does not hide the missing URN nid'
+  )
+  t.end()
+})
+
+test('equal returns false for malformed ordinary URNs', (t) => {
+  for (const uri of malformedURNs) {
+    t.equal(fastURI.equal(uri, uri, {}), false, `${uri} is not equal to itself as malformed input`)
+    t.equal(fastURI.equal(uri, 'urn:foo:bar', {}), false, `${uri} is not equal to a valid URN`)
+  }
+  t.end()
+})
+
+test('valid URNs retain their existing behavior', (t) => {
+  t.equal(fastURI.normalize('URN:FOO:a123,456'), 'urn:foo:a123,456')
+  t.equal(fastURI.equal('urn:foo:a123,456', 'URN:FOO:a123,456', {}), true)
+  t.equal(fastURI.resolve('uri://base/', 'urn:'), 'urn:', 'default resolve behavior is unchanged')
+  t.end()
+})


### PR DESCRIPTION
## Summary

- carry malformed ordinary URN status through parse-to-serialize paths
- preserve malformed URN strings during normalization
- make malformed URN equality return `false` while retaining explicit component serialization errors

Built from the current `main` branch and supersedes #206.

## Tests

- `npm test`
- `npm run lint`
- `npm run test:typescript`
