### PR TITLE
normalize: decode %2E in a path segment that isn't a dot-segment

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -411,14 +411,29 @@ function percentEncodeNonAscii (cp) {
 }
 
 /**
- * Normalizes path data without turning reserved escapes into live path syntax.
- * Valid escapes are uppercased, raw unsafe characters are escaped, and only
- * unreserved bytes that are not `.` are decoded.
+ * True when a path segment is a dot-segment (`.` or `..`), reading `%2E` as a
+ * literal dot. Such a segment keeps its dots percent-encoded, so a traversal
+ * spelled `%2E%2E` cannot be decoded and then collapsed by removeDotSegments.
+ *
+ * @param {string} segment
+ * @returns {boolean}
+ */
+function isDotSegment (segment) {
+  const decoded = segment.replace(/%2e/giu, '.')
+  return decoded === '.' || decoded === '..'
+}
+
+/**
+ * Normalizes a single path segment. Valid escapes are uppercased, raw unsafe
+ * characters are escaped, and unreserved bytes are decoded. A `%2E` decodes
+ * like any other unreserved byte unless the segment is a dot-segment, where it
+ * stays encoded.
  *
  * @param {string} input
  * @returns {string}
  */
-function normalizePathEncoding (input) {
+function normalizePathSegment (input) {
+  const keepDotsEncoded = isDotSegment(input)
   let output = ''
 
   for (let i = 0; i < input.length; i++) {
@@ -429,7 +444,7 @@ function normalizePathEncoding (input) {
         const normalizedHex = hex.toUpperCase()
         const decoded = String.fromCharCode(parseInt(normalizedHex, 16))
 
-        if (decoded !== '.' && isUnreserved(decoded)) {
+        if (isUnreserved(decoded) && !(decoded === '.' && keepDotsEncoded)) {
           output += decoded
         } else {
           output += '%' + normalizedHex
@@ -463,6 +478,23 @@ function normalizePathEncoding (input) {
   }
 
   return output
+}
+
+/**
+ * Normalizes path data without turning reserved escapes into live path syntax.
+ * Each segment is handled on its own so a `%2E` is only kept encoded when the
+ * segment is a dot-segment; a dot inside a longer segment (`foo%2Ebar`,
+ * `%2Ehidden`) is an unreserved byte and is decoded per RFC 3986 6.2.2.2.
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function normalizePathEncoding (input) {
+  const segments = input.split('/')
+  for (let i = 0; i < segments.length; i++) {
+    segments[i] = normalizePathSegment(segments[i])
+  }
+  return segments.join('/')
 }
 
 /**

--- a/test/reserved-path-normalization.test.js
+++ b/test/reserved-path-normalization.test.js
@@ -107,3 +107,27 @@ test('equal distinguishes escaped reserved path data from literal syntax', (t) =
   )
   t.end()
 })
+
+test('normalize decodes an escaped dot that is not a dot-segment', (t) => {
+  t.equal(
+    fastURI.normalize('http://example.com/foo%2Ebar'),
+    'http://example.com/foo.bar',
+    'decodes %2E inside a longer segment, like other unreserved bytes'
+  )
+  t.equal(
+    fastURI.normalize('http://example.com/%2Ehidden'),
+    'http://example.com/.hidden',
+    'decodes a leading %2E when the segment is not "." or ".."'
+  )
+  t.equal(
+    fastURI.normalize('http://example.com/a/%2e/b'),
+    'http://example.com/a/%2E/b',
+    'keeps %2E encoded when the whole segment is a dot-segment'
+  )
+  t.equal(
+    fastURI.equal('http://example.com/foo%2Ebar', 'http://example.com/foo.bar', {}),
+    true,
+    'an escaped dot and a literal dot compare equal outside a dot-segment'
+  )
+  t.end()
+})


### PR DESCRIPTION
`normalize()` leaves `%2E` percent-encoded everywhere in the path, so `http://h/foo%2Ebar` stays `foo%2Ebar` and `equal('.../foo%2Ebar', '.../foo.bar')` returns false. But `.` is unreserved (RFC 3986 §2.3) and should be decoded (§6.2.2.2) — the query and fragment normalizers already do, and every other unreserved byte (`-` `_` `~`) is decoded in the path.

The blanket `decoded !== '.'` guard exists to stop `%2E%2E` from decoding into `..` and being collapsed by `removeDotSegments` (a traversal defense), but it is too broad. This decides per segment: `%2E` stays encoded only when the segment is exactly `.` or `..`, and decodes otherwise. `/public/%2E%2E/admin` is unchanged and the security-normalization tests still pass.
