### PR TITLE
fix: validate malformed IPv6 zone identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -351,12 +351,18 @@ function hasMalformedComponentPercentEncoding (matches) {
  * @returns {boolean} whether host conversion failed
  */
 function canonicalizeHost (parsed, options, schemeHandler, isIP) {
+  const bracketedIPLiteral =
+    parsed.host &&
+    parsed.host[0] === '[' &&
+    parsed.host[parsed.host.length - 1] === ']'
+
   if (
     !options.unicodeSupport &&
     (!schemeHandler || !schemeHandler.unicodeSupport) &&
     parsed.host &&
     (options.domainHost || (schemeHandler && schemeHandler.domainHost)) &&
     isIP === false &&
+    !bracketedIPLiteral &&
     nonSimpleDomain(parsed.host)
   ) {
     try {
@@ -366,6 +372,7 @@ function canonicalizeHost (parsed, options, schemeHandler, isIP) {
       return true
     }
   }
+
   return false
 }
 

--- a/test/ipv6-validation.test.js
+++ b/test/ipv6-validation.test.js
@@ -88,3 +88,34 @@ test('valid IPv6, IPvFuture, embedded IPv4, and zone forms normalize safely', (t
   }
   t.end()
 })
+
+test('IPv6 zone identifiers are validated correctly', (t) => {
+  const valid = [
+    'http://[fe80::1%25eth0]/',
+    'http://[fe80::a%en1]/',
+    'http://[fe80::a%25eth%2D0]/'
+  ]
+
+  for (const uri of valid) {
+    const parsed = fastURI.parse(uri)
+
+    t.equal(parsed.error, undefined, `${uri} parses without error`)
+  }
+
+  const malformed = [
+    'http://[fe80::1%25]/',
+    'http://[fe80::1%25eth 0]/',
+    'http://[fe80::1%25eth%ZZ]/',
+    'http://[fe80::1%25K]/'
+  ]
+
+  for (const uri of malformed) {
+    const parsed = fastURI.parse(uri)
+
+    t.equal(parsed.error, HOST_ERROR, `${uri} is rejected`)
+    t.equal(fastURI.normalize(uri), uri, `${uri} is not rewritten`)
+    t.equal(fastURI.equal(uri, uri), false, `${uri} is not comparable`)
+  }
+
+  t.end()
+})


### PR DESCRIPTION
Proposal:

Fix malformed IPv6 zone identifier handling in bracketed IP literals.

When parsing IPv6 zone identifiers, malformed values such as:

- `fe80::1%25`
- `fe80::1%25eth 0`
- `fe80::1%25eth%ZZ`
- `fe80::1%25K`

must be rejected rather than silently rewritten.

This is particularly relevant on Node.js 16, where the native `URL` parser can truncate these values instead of reporting an invalid host.

Changes:

- Validate IPv6 zone identifiers explicitly in `normalizeIPv6()`.
- Reject empty, whitespace-containing and malformed percent-encoded zone identifiers.
- Preserve the original malformed host instead of truncating or rewriting it.
- Add regression tests for valid and malformed IPv6 zone identifiers.

Note:

- Tested with Node.js 16.20.2
- Fix test in CI ( see screenshot ) or https://github.com/fastify/fast-uri/actions/runs/32536858344/job/97013696061#step:5:244

<img width="1346" height="1226" alt="Screenshot 2026-08-22 alle 12 12 39" src="https://github.com/user-attachments/assets/06ab3f57-88c1-46c3-995f-0292aa94b9a9" />
