### PR TITLE
fix: treat unterminated bracket hosts as reg-names again

### DIFF
--- a/index.js
+++ b/index.js
@@ -329,6 +329,18 @@ function hasMalformedPercentEncoding (component) {
 }
 
 /**
+ * Whether the host is a bracketed IP literal (RFC 3986 `IP-literal`).
+ * An unterminated `[` is not a literal, so it must still be validated as a
+ * reg-name instead of being waved through as an IP.
+ *
+ * @param {string} host
+ * @returns {boolean}
+ */
+function isIPLiteral (host) {
+  return host[0] === '[' && host[host.length - 1] === ']'
+}
+
+/**
  * @param {RegExpMatchArray} matches
  * @returns {boolean}
  */
@@ -337,7 +349,7 @@ function hasMalformedComponentPercentEncoding (matches) {
   // compatibility. Their parsing is intentionally left to normalizeIPv6.
   const host = matches[4]
   return hasMalformedPercentEncoding(matches[3]) ||
-    (host !== undefined && !(host[0] === '[' && host[host.length - 1] === ']') && hasMalformedPercentEncoding(host)) ||
+    (host !== undefined && !isIPLiteral(host) && hasMalformedPercentEncoding(host)) ||
     hasMalformedPercentEncoding(matches[6]) ||
     hasMalformedPercentEncoding(matches[7]) ||
     hasMalformedPercentEncoding(matches[8])
@@ -355,7 +367,7 @@ function canonicalizeHost (parsed, options, schemeHandler, isIP) {
     !options.unicodeSupport &&
     (!schemeHandler || !schemeHandler.unicodeSupport) &&
     parsed.host &&
-    parsed.host[0] !== '[' &&
+    !isIPLiteral(parsed.host) &&
     (options.domainHost || (schemeHandler && schemeHandler.domainHost)) &&
     isIP === false &&
     nonSimpleDomain(parsed.host)

--- a/test/ipv6-validation.test.js
+++ b/test/ipv6-validation.test.js
@@ -88,3 +88,19 @@ test('valid IPv6, IPvFuture, embedded IPv4, and zone forms normalize safely', (t
   }
   t.end()
 })
+
+test('unterminated bracket hosts are not treated as IP literals', (t) => {
+  const unterminated = [
+    'http://[fe80',
+    'http://[',
+    'http://[not-an-ip',
+    'http://[\u65e5\u672c'
+  ]
+
+  for (const uri of unterminated) {
+    const parsed = fastURI.parse(uri)
+    t.ok(parsed.error, `parse rejects ${uri}`)
+    t.equal(fastURI.normalize(uri), uri, `normalize preserves ${uri}`)
+  }
+  t.end()
+})


### PR DESCRIPTION
5a77ac7 (v4.1.3) added a `parsed.host[0] !== '['` guard to `canonicalizeHost` so bracketed IP literals never reach the WHATWG IDN fallback. The intent was right, but the check also matches hosts where the `[` is never closed — and those are not IP literals at all.

## Regression

Before 5a77ac7 (`5a77ac7~1`), an unterminated bracket host failed closed:

```js
// 5a77ac72~1
uri.parse('http://[fe80').error
// 'URI host is malformed.'
```

After 5a77ac7 the guard skips canonicalization for anything starting with `[`, so the same input now parses without any error:

```js
// v4.1.3 (master)
uri.parse('http://[fe80').error
// undefined        <- accepted
uri.parse('http://[').error
// undefined        <- accepted
uri.parse('http://[not-an-ip').error
// undefined        <- accepted
```

All four of these throw in Node's WHATWG `URL`, so fast-uri went from stricter-than-WHATWG to accepting inputs WHATWG rejects. fast-uri backs ajv's `uri` format, so schemas validating URI-formatted strings now accept these.

## Fix

Gate the skip on a *fully* bracketed host instead of merely one that starts with `[`. The same "starts with `[` and ends with `]`" test already existed inline in `hasMalformedComponentPercentEncoding`; it is extracted into an `isIPLiteral()` helper and reused by both call sites.

- `http://[fe80::1]`, `http://[fe80::1%25]` → still skip canonicalization (the fix's original goal)
- `http://[fe80`, `http://[`, `http://[not-an-ip` → back to failing with `URI host is malformed.`

## Tests

Added `unterminated bracket hosts are not treated as IP literals` to `test/ipv6-validation.test.js`. It fails on master (8 assertions) and passes with this change.

Full suite: 1611 passing.
