### PR TITLE
fix: backport port and IP-literal validation to v2.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -435,10 +435,11 @@ function parseWithStatus (uri, opts) {
     if (parsed.host) {
       const ipv4result = isIPv4(parsed.host)
       if (ipv4result === false) {
-        const bracketedIPLiteral = parsed.host[0] === '[' && parsed.host[parsed.host.length - 1] === ']'
+        const bracketedIPLiteral = isIPLiteral(parsed.host)
+        const hasIPLiteralBracket = parsed.host.indexOf('[') !== -1 || parsed.host.indexOf(']') !== -1
         const ipv6result = normalizeIPv6(parsed.host)
         isIP = ipv6result.isIPV6 || ipv6result.isIPVFuture === true
-        malformedIPLiteral = bracketedIPLiteral && ipv6result.error === true
+        malformedIPLiteral = hasIPLiteralBracket && (!bracketedIPLiteral || ipv6result.error === true)
         parsed.host = isIP ? ipv6result.host : ipv6result.host.toLowerCase()
 
         if (malformedIPLiteral) {
@@ -468,7 +469,9 @@ function parseWithStatus (uri, opts) {
     const schemeHandler = SCHEMES[(options.scheme || parsed.scheme || '').toLowerCase()]
 
     // convert Unicode IDN -> ASCII IDN when the effective scheme uses domain hosts
-    malformedHost = canonicalizeHost(parsed, options, schemeHandler, isIP)
+    if (!malformedIPLiteral) {
+      malformedHost = canonicalizeHost(parsed, options, schemeHandler, isIP)
+    }
 
     if (!schemeHandler || (schemeHandler && !schemeHandler.skipNormalize)) {
       if (parsed.host !== undefined && !malformedIPLiteral) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,9 @@ const { HEX } = require('./scopedChars')
 /** @type {(value: string) => boolean} */
 const isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u)
 
+/** @type {(value: string) => boolean} */
+const isPort = RegExp.prototype.test.bind(/^\d*$/u)
+
 /**
  * @param {string[]} input
  * @param {boolean} [keepZero=false]
@@ -630,8 +633,12 @@ function recomposeAuthority (components, options) {
   }
 
   if (typeof components.port === 'number' || typeof components.port === 'string') {
+    const port = String(components.port)
+    if (!isPort(port)) {
+      throw new TypeError('URI port is malformed.')
+    }
     uriTokens.push(':')
-    uriTokens.push(String(components.port))
+    uriTokens.push(port)
   }
 
   return uriTokens.length ? uriTokens.join('') : undefined

--- a/test/component-safe-serialization.test.js
+++ b/test/component-safe-serialization.test.js
@@ -24,6 +24,64 @@ test('userinfo serialization cannot terminate the authority', (t) => {
   t.end()
 })
 
+test('port serialization rejects non-digit values', (t) => {
+  const malformedPorts = [
+    '@127.0.0.1:8124',
+    '8080@evil.example',
+    '8080/path',
+    '8080?query',
+    '8080#fragment',
+    '8080:9000',
+    '-1',
+    '1.5',
+    1.5,
+    NaN,
+    Infinity,
+    '\u0661'
+  ]
+
+  for (const port of malformedPorts) {
+    t.throws(
+      () => fastURI.serialize({ scheme: 'http', host: 'trusted.example', port, path: '/app' }),
+      /URI port is malformed\./,
+      String(port)
+    )
+  }
+
+  t.throws(
+    () => fastURI.normalize({ scheme: 'http', host: 'trusted.example', port: '@evil.example' }),
+    /URI port is malformed\./,
+    'object normalization rejects a malformed port'
+  )
+  t.equal(
+    fastURI.equal(
+      { scheme: 'http', host: 'trusted.example', port: '@evil.example' },
+      { scheme: 'http', host: 'trusted.example', port: '@evil.example' }
+    ),
+    false,
+    'object equality fails closed for a malformed port'
+  )
+  t.end()
+})
+
+test('port serialization preserves RFC 3986 digit values', (t) => {
+  const validPorts = [
+    [8080, '8080'],
+    ['8080', '8080'],
+    ['00080', '00080'],
+    ['', '']
+  ]
+
+  for (const [port, expected] of validPorts) {
+    t.equal(
+      fastURI.serialize({ scheme: 'uri', host: 'example.test', port }),
+      `uri://example.test:${expected}`,
+      JSON.stringify(port)
+    )
+  }
+  t.end()
+})
+
 test('query and fragment serialization cannot inject component delimiters', (t) => {
   const uri = fastURI.serialize({
     scheme: 'x',

--- a/test/ipv6-validation.test.js
+++ b/test/ipv6-validation.test.js
@@ -3,18 +3,38 @@
 const test = require('tape')
 const fastURI = require('..')
 
-test('unterminated bracket hosts are not treated as IP literals', (t) => {
-  const unterminated = [
+const HOST_ERROR = 'URI host is malformed.'
+
+test('hosts with unbalanced or misplaced IP-literal brackets are rejected', (t) => {
+  const malformed = [
     'http://[fe80',
     'http://[',
     'http://[not-an-ip',
-    'http://[\u65e5\u672c'
+    'http://[\u65e5\u672c',
+    'http://user@[@127.0.0.1:8123/admin',
+    'http://user@]127.0.0.1:8123/admin',
+    'http://user@prefix[@127.0.0.1:8123/admin',
+    'http://user@prefix]@127.0.0.1:8123/admin'
+  ]
+  const modes = [
+    ['default', undefined],
+    ['Unicode', { unicodeSupport: true }]
   ]
 
-  for (const uri of unterminated) {
-    const parsed = fastURI.parse(uri)
-    t.ok(parsed.error, `parse rejects ${uri}`)
-    t.equal(fastURI.normalize(uri), uri, `normalize preserves ${uri}`)
+  for (const [mode, options] of modes) {
+    for (const uri of malformed) {
+      const parsed = fastURI.parse(uri, options)
+      const message = `${mode} mode rejects ${uri}`
+
+      t.equal(parsed.error, HOST_ERROR, `parse ${message}`)
+      t.equal(fastURI.normalize(uri, options), uri, `normalize preserves ${uri} in ${mode} mode`)
+      t.equal(fastURI.equal(uri, uri, options), false, `equal ${message}`)
+      t.throws(
+        () => fastURI.resolve('http://example.com/', uri, options),
+        /URI host is malformed\./,
+        `resolve ${message}`
+      )
+    }
   }
   t.end()
 })


### PR DESCRIPTION
Backport 820e8478dd7da3d09f187bfaf35d50b71f67b8b4 and 506b155db72d67faee03e8dff7e0136d4f68f28b to v2.x. This rejects non-digit serialized ports and malformed hosts with unbalanced or misplaced IP-literal brackets.
